### PR TITLE
feat: Add override setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This plugin currently support:
 - [x] Auto-rename the attachment when paste file to `markdown` or `canvas`
 - [x] Auto-rename the attachment file or folder while your rename the article (`markdown` or `canvas`) file
 - [x] Auto-rename the attachment when drop file to `markdown` or `canvas`
-- [x] Re-Arrange the attachment file that linked by `markdown` or `canvas` to corresponding path as you configured (experimental)
+- [ ] ~~Re-Arrange the attachment file that linked by `markdown` or `canvas` to corresponding path as you configured (experimental)~~
 - [ ] Processing duplicate attachment
 - [ ] Override attachment configuration for specified notes or folder
 
@@ -58,7 +58,7 @@ Set how to rename the attachment, available variables `${notename}` and `${date}
 
 ### Date Format
 
-Use [Moment format options](https://momentjscom.readthedocs.io/en/latest/moment/04-displaying/01-format) to set the `${date}`, default value `YYYYMMDDHHmmssSSS`.
+Use [Moment format options](https://momentjscom.readthedocs.io/en/latest/moment/04-displaying/01-format) to set the `${date}`, default value `YYYYMMDDHHmmssSSS`. You should always use the `${date}` variable to prevent the same file name.
 
 ### Handle All Attachments
 
@@ -82,10 +82,21 @@ This plugin support a command `Rearrange Linked Attachments`, if you run this co
 
 ![SCR-20230511-rrtk](./images/SCR-20230511-rrtk.png)
 
-**Notice** The `Rearrange Linked Attachments` was currently a experimental feature, if you want to try out, it's better to backup your files at first.
+~~**Notice** The `Rearrange Linked Attachments` was currently a experimental feature, if you want to try out, it's better to backup your files at first.~~
+
+### Overriding Setting
+
+Your can set the attachment path setting for file or folder. The priority of these setting are:
+
+```
+file setting > most close parent folder setting > global setting
+```
+
+If you want to reset the setting of files or folder to the global setting, use the command `Reset Override Setting` or the `Reset` button of override setting panel. By the way, **the reset will only working on each file or folder that you have set on**. The more appropriate method to handle the reset will be add in future.
 
 ### Known Issues
 
+- No support for processing duplicated file name right now (in develop).
 - When drop a file in `canvas`, it's will delay to show the updated link/filename.
 
 ![Screen Recording](./images/canvas_drop_delay.gif)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You must select a root folder to save the associated attachment of a `markdown` 
 It can be set use the config of obsidian in `Files & Links`, or reset in this option.
 
 - Copy Obsidian settings: use the config of obsidian in `Files & Links`.
-- In the folder specified below: set a fixd folder.
+- In the folder specified below: set a fixed folder.
 - Next to note in folder specified below: in the subfolder of current `markdown` or `canvas` file.
 
 ### Attachment Path

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -3,9 +3,6 @@ export const RENAME_EVENT_TYPE_FILE = "RENAME_EVENT_TYPE_FILE";
 
 export type RenameEventType = typeof RENAME_EVENT_TYPE_FOLDER | typeof RENAME_EVENT_TYPE_FILE;
 
-export const EDITOR_DROP_EVENT = "EDITOR_DROP_EVENT";
-export const DOM_DROP_EVENT = "DOM_DROP_EVENT";
-
 export const SETTINGS_VARIABLES_DATES = "${date}";
 export const SETTINGS_VARIABLES_NOTEPATH = "${notepath}";
 export const SETTINGS_VARIABLES_NOTENAME = "${notename}";

--- a/src/main.ts
+++ b/src/main.ts
@@ -67,6 +67,23 @@ export default class AttachmentManagementPlugin extends Plugin {
       },
     });
 
+    this.addCommand({
+      id: "attachment-management-reset-override-setting",
+      name: "Reset Override Setting",
+      callback: async () => {
+        const file = this.getActiveFile();
+        if (file === undefined) {
+          new Notice("Error: no active file found.");
+          return;
+        }
+        delete this.settings.overridePath[file.path]
+        await this.saveSettings();
+        await this.loadSettings();
+        const oldSetting = getOverrideSetting(this.settings, file);
+        const fileSetting = Object.assign({}, oldSetting);
+      },
+    });
+
     this.registerEvent(
       this.app.workspace.on("file-menu", (menu, file) => {
         menu.addItem((item) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,11 +41,11 @@ export default class AttachmentManagementPlugin extends Plugin {
     this.adapter = this.app.vault.adapter as FileSystemAdapter;
     // this.backupConfigs();
 
-    this.addCommand({
-      id: "attachment-management-rearrange-links",
-      name: "Rearrange Linked Attachments",
-      callback: () => this.rearrangeAttachment("links"),
-    });
+    // this.addCommand({
+    //   id: "attachment-management-rearrange-links",
+    //   name: "Rearrange Linked Attachments",
+    //   callback: () => this.rearrangeAttachment("links"),
+    // });
 
     // this.addCommand({
     //   id: "obsidian-attachment-rearrange-all",
@@ -80,6 +80,7 @@ export default class AttachmentManagementPlugin extends Plugin {
         delete this.settings.overridePath[file.path];
         await this.saveSettings();
         await this.loadSettings();
+        new Notice(`Reset attachment setting of ${file.path}`);
       },
     });
 
@@ -140,6 +141,8 @@ export default class AttachmentManagementPlugin extends Plugin {
         // TODO: update overriding setting path
         if (setting.type === SETTINGS_TYPE_FOLDER || setting.type === SETTINGS_TYPE_FILE) {
           updateOverrideSetting(this.settings, file, oldPath);
+          await this.saveSettings();
+          await this.loadSettings();
         }
 
         if (!this.settings.autoRenameAttachment) {
@@ -209,14 +212,10 @@ export default class AttachmentManagementPlugin extends Plugin {
       }
       const { setting } = getOverrideSetting(this.settings, innerFile);
 
-      if (
-        !setting.attachmentPath.includes(SETTINGS_VARIABLES_NOTENAME) &&
-        !setting.attachmentPath.includes(SETTINGS_VARIABLES_NOTEPATH) &&
-        !setting.attachFormat.includes(SETTINGS_VARIABLES_NOTENAME) &&
-        !setting.attachFormat.includes(SETTINGS_VARIABLES_DATES)
-      ) {
-        debugLog("No Variable Use, continue");
-        continue;
+      const type = attachRenameType(setting);
+      if (type === ATTACHMENT_RENAME_TYPE.ATTACHMENT_RENAME_TYPE_NULL) {
+        debugLog("No variable use, skipped");
+        return;
       }
 
       for (let link of attachments[obsFile]) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,7 +88,7 @@ export default class AttachmentManagementPlugin extends Plugin {
       this.app.workspace.on("file-menu", (menu, file) => {
         menu.addItem((item) => {
           item
-            .setTitle("Set attachment path")
+            .setTitle("Override attachment setting")
             .setIcon("image-plus")
             .onClick(async () => {
               const oldSetting = getOverrideSetting(this.settings, file);

--- a/src/override.ts
+++ b/src/override.ts
@@ -20,7 +20,7 @@ export class OverrideModal extends Modal {
     super(plugin.app);
     this.plugin = plugin;
     this.file = file;
-    debugLog(setting);
+    debugLog("setting:", this.file.path, setting);
     this.setting = setting;
   }
 
@@ -121,7 +121,7 @@ export class OverrideModal extends Modal {
             }
             this.plugin.settings.overridePath[this.file.path] = this.setting;
             this.plugin.saveSettings();
-            debugLog(`Override Settings, ${this.file.path}: ${this.setting}`);
+            debugLog("Overriding Settings:", this.file.path, this.setting);
             this.close();
           })
       );

--- a/src/override.ts
+++ b/src/override.ts
@@ -105,7 +105,7 @@ export class OverrideModal extends Modal {
           delete this.plugin.settings.overridePath[this.file.path]
           await this.plugin.saveSettings();
           await this.plugin.loadSettings();
-          new Notice("Reset attachment path setting");
+          new Notice(`Reset attachment setting of ${this.file.path}`);
           this.close();
         });
       })

--- a/src/override.ts
+++ b/src/override.ts
@@ -44,7 +44,7 @@ export class OverrideModal extends Modal {
       text: "Override Settings",
     });
 
-    const rootSetting = new Setting(contentEl)
+    new Setting(contentEl)
       .setName("Root path to save new attachments")
       .setDesc("Select root path for all new attachments")
       .addDropdown((text) =>
@@ -100,11 +100,11 @@ export class OverrideModal extends Modal {
 
     new Setting(contentEl)
       .addButton((btn) => {
-        btn.setButtonText("Reset").onClick(() => {
+        btn.setButtonText("Reset").onClick(async () => {
           this.setting = this.plugin.settings.attachPath;
           delete this.plugin.settings.overridePath[this.file.path]
-          this.plugin.saveSettings();
-          this.plugin.loadSettings();
+          await this.plugin.saveSettings();
+          await this.plugin.loadSettings();
           new Notice("Reset attachment path setting");
           this.close();
         });

--- a/src/override.ts
+++ b/src/override.ts
@@ -1,0 +1,123 @@
+import { Modal, TFile, App, TAbstractFile, Setting, TFolder } from "obsidian";
+import { debugLog } from "./utils";
+import { AttachmentPathSettings, DEFAULT_SETTINGS, SETTINGS_TYPE_FILE, SETTINGS_TYPE_FOLDER } from "./settings";
+import {
+  SETTINGS_ROOT_OBSFOLDER,
+  SETTINGS_ROOT_INFOLDER,
+  SETTINGS_ROOT_NEXTTONOTE,
+  SETTINGS_VARIABLES_NOTEPATH,
+  SETTINGS_VARIABLES_NOTENAME,
+  SETTINGS_VARIABLES_DATES,
+} from "./constant";
+import AttachmentManagementPlugin from "./main";
+
+export class OverrideModal extends Modal {
+  plugin: AttachmentManagementPlugin;
+  file: TAbstractFile;
+  setting: AttachmentPathSettings;
+
+  constructor(plugin: AttachmentManagementPlugin, file: TAbstractFile, setting: AttachmentPathSettings) {
+    super(plugin.app);
+    this.plugin = plugin;
+    this.file = file;
+    this.setting = setting;
+  }
+
+  displSw(cont: HTMLElement): void {
+    cont.findAll(".setting-item").forEach((el: HTMLElement) => {
+      if (el.getAttr("class")?.includes("override_root_folder_set")) {
+        if (this.setting.saveAttE === "obsFolder") {
+          el.hide();
+        } else {
+          el.show();
+        }
+      }
+    });
+  }
+
+  onOpen() {
+    let { contentEl } = this;
+    contentEl.empty();
+
+    contentEl.createEl("h2", {
+      text: "Override Settings",
+    });
+
+    new Setting(contentEl)
+      .setName("Root path to save new attachments")
+      .setDesc("Select root path for all new attachments")
+      .addDropdown((text) =>
+        text
+          .addOption(`${SETTINGS_ROOT_OBSFOLDER}`, "Copy Obsidian settings")
+          .addOption(`${SETTINGS_ROOT_INFOLDER}`, "In the folder specified below")
+          .addOption(`${SETTINGS_ROOT_NEXTTONOTE}`, "Next to note in folder specified below")
+          .setValue(this.setting.saveAttE)
+          .onChange(async (value) => {
+            this.setting.saveAttE = value;
+            this.displSw(contentEl);
+          })
+      );
+
+    new Setting(contentEl)
+      .setName("Root folder")
+      .setClass("override_root_folder_set")
+      .addText((text) =>
+        text
+          .setPlaceholder(DEFAULT_SETTINGS.attachPath.attachmentRoot)
+          .setValue(this.setting.attachmentRoot)
+          .onChange(async (value) => {
+            console.log("Attachment root: " + value);
+            this.setting.attachmentRoot = value;
+          })
+      );
+
+    new Setting(contentEl)
+      .setName("Attachment path")
+      .setDesc(`Path of new attachment in root folder, available variables ${SETTINGS_VARIABLES_NOTEPATH} and ${SETTINGS_VARIABLES_NOTENAME}`)
+      .addText((text) =>
+        text
+          .setPlaceholder(DEFAULT_SETTINGS.attachPath.attachmentPath)
+          .setValue(this.setting.attachmentPath)
+          .onChange(async (value) => {
+            console.log("Attachment path: " + value);
+            this.setting.attachmentPath = value;
+          })
+      );
+
+    new Setting(contentEl)
+      .setName("Attachment format")
+      .setDesc(`Define how to name the attachment file, available variables ${SETTINGS_VARIABLES_DATES} and ${SETTINGS_VARIABLES_NOTENAME}`)
+      .addText((text) =>
+        text
+          .setPlaceholder(DEFAULT_SETTINGS.attachPath.attachFormat)
+          .setValue(this.setting.attachFormat)
+          .onChange(async (value: string) => {
+            console.log("Attachment format: " + value);
+            this.setting.attachFormat = value;
+          })
+      );
+
+    new Setting(contentEl).addButton((btn) =>
+      btn
+        .setButtonText("Submit")
+        .setCta()
+        .onClick(() => {
+          if (this.file instanceof TFile) {
+            this.setting.type = SETTINGS_TYPE_FILE;
+          } else if (this.file instanceof TFolder) {
+            this.setting.type = SETTINGS_TYPE_FOLDER;
+          }
+          this.plugin.settings.overridePath[this.file.path] = this.setting;
+          this.plugin.saveSettings();
+          this.close();
+        })
+    );
+
+    this.displSw(contentEl);
+  }
+
+  onClose() {
+    let { contentEl } = this;
+    contentEl.empty();
+  }
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -69,7 +69,7 @@ export class SettingTab extends PluginSettingTab {
     this.plugin = plugin;
   }
 
-  displSw(cont: HTMLElement): void {
+  displaySw(cont: HTMLElement): void {
     cont.findAll(".setting-item").forEach((el: HTMLElement) => {
       if (el.getAttr("class")?.includes("root_folder_set")) {
         if (this.plugin.settings.attachPath.saveAttE === "obsFolder") {
@@ -108,7 +108,7 @@ export class SettingTab extends PluginSettingTab {
           .setValue(this.plugin.settings.attachPath.saveAttE)
           .onChange(async (value) => {
             this.plugin.settings.attachPath.saveAttE = value;
-            this.displSw(containerEl);
+            this.displaySw(containerEl);
             await this.plugin.saveSettings();
           })
       );
@@ -185,7 +185,7 @@ export class SettingTab extends PluginSettingTab {
         toggle.setValue(this.plugin.settings.handleAll).onChange(async (value) => {
           console.log("Handle All Create Attachment: " + value);
           this.plugin.settings.handleAll = value;
-          this.displSw(containerEl);
+          this.displaySw(containerEl);
           await this.plugin.saveSettings();
         })
       );
@@ -229,6 +229,6 @@ export class SettingTab extends PluginSettingTab {
     // 			})
     // 	);
 
-    this.displSw(containerEl);
+    this.displaySw(containerEl);
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -282,9 +282,9 @@ export function needToRename(settings: AttachmentPathSettings, attachPath: strin
   return false;
 }
 
-export function getOverrideSetting(overrideSettings: Record<string, AttachmentPathSettings>, file: TAbstractFile): AttachmentPathSettings | undefined {
-  if (Object.keys(overrideSettings).length === 0) {
-    return undefined;
+export function getOverrideSetting(settings: AttachmentManagementPluginSettings, file: TAbstractFile): AttachmentPathSettings {
+  if (Object.keys(settings.overridePath).length === 0) {
+    return settings.attachPath;
   }
 
   let candidates: Record<string, AttachmentPathSettings> = {};
@@ -293,8 +293,8 @@ export function getOverrideSetting(overrideSettings: Record<string, AttachmentPa
   fileType = file instanceof TFile ? true : false;
   fileType = file instanceof TFolder ? false : true;
 
-  for (const overridePath of Object.keys(overrideSettings)) {
-    const overrideSetting = overrideSettings[overridePath];
+  for (const overridePath of Object.keys(settings.overridePath)) {
+    const overrideSetting = settings.overridePath[overridePath];
     if (fileType) {
       if (overridePath === file.path && overrideSetting.type === SETTINGS_TYPE_FILE) {
         // best match
@@ -312,7 +312,7 @@ export function getOverrideSetting(overrideSettings: Record<string, AttachmentPa
   }
 
   if (Object.keys(candidates).length === 0) {
-    return undefined;
+    return settings.attachPath;
   }
 
   const sortedK = Object.keys(candidates).sort((a, b) => (a.split("/").length < b.split("/").length ? -1 : a.split("/").length > b.split("/").length ? 1 : 0));
@@ -323,5 +323,5 @@ export function getOverrideSetting(overrideSettings: Record<string, AttachmentPa
     }
   }
 
-  return undefined;
+  return settings.attachPath;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,9 +5,13 @@ import { AttachmentManagementPluginSettings, AttachmentPathSettings, SETTINGS_TY
 import { SETTINGS_VARIABLES_DATES, SETTINGS_VARIABLES_NOTENAME, SETTINGS_VARIABLES_NOTEPATH } from "./constant";
 
 export enum ATTACHMENT_RENAME_TYPE {
+  // need to rename the attachment folder and file name
   ATTACHMENT_RENAME_TYPE_BOTH = "BOTH",
+  // need to rename the attachment folder
   ATTACHMENT_RENAME_TYPE_FOLDER = "FOLDER",
+  // need to rename the attachment file name
   ATTACHMENT_RENAME_TYPE_FILE = "FILE",
+  // no need to rename
   ATTACHMENT_RENAME_TYPE_NULL = "NULL",
 }
 
@@ -66,13 +70,18 @@ export function isImage(extension: string): boolean {
   return false;
 }
 
-// find the first prefix difference of two paths
-// e.g.:
-//     "Resources/Untitled/Untitled 313/Untitled"
-//     "Resources/Untitled1/Untitled 313/Untitled"
-// result:
-//     "Resources/Untitled"
-//     "Resources/Untitled1"
+/**
+ * find the first prefix difference of two paths
+ * e.g.:
+ *   "Resources/Untitled/Untitled 313/Untitled"
+ *   "Resources/Untitled1/Untitled 313/Untitled"
+ * result:
+ *   "Resources/Untitled"
+ *   "Resources/Untitled1"
+ * @param src source path
+ * @param dst destination path
+ * @returns the first different prefix, otherwise, return the original path
+ */
 export function stripPaths(src: string, dst: string): { nsrc: string; ndst: string } {
   if (src === dst) {
     return { nsrc: src, ndst: dst };
@@ -103,6 +112,12 @@ export function stripPaths(src: string, dst: string): { nsrc: string; ndst: stri
   return { nsrc: "", ndst: "" };
 }
 
+/**
+ * Test if the extension is matched by pattern
+ * @param extension extension of a file
+ * @param pattern patterns for match extension
+ * @returns true if matched, false otherwise
+ */
 export function testExcludeExtension(extension: string, pattern: string): boolean {
   if (!pattern || pattern === "") return false;
   return new RegExp(pattern).test(extension);
@@ -233,7 +248,7 @@ export async function isAttachment(settings: AttachmentManagementPluginSettings,
   return false;
 }
 
-const addToRecord = (record: Record<string, Set<string>>, key: string, value: Set<string>) => {
+export function addToRecord(record: Record<string, Set<string>>, key: string, value: Set<string>){
   if (record[key] === undefined) {
     record[key] = value;
     return;
@@ -245,17 +260,17 @@ const addToRecord = (record: Record<string, Set<string>>, key: string, value: Se
   }
 
   record[key] = valueSet;
-};
+}
 
-const addToSet = (setObj: Set<string>, value: string) => {
+export function addToSet (setObj: Set<string>, value: string) {
   if (!setObj.has(value)) {
     setObj.add(value);
   }
-};
+}
 
-const pathIsAnImage = (path: string) => {
+export function pathIsAnImage (path: string) {
   return path.match(imageRegex);
-};
+}
 
 export function attachRenameType(setting: AttachmentPathSettings): ATTACHMENT_RENAME_TYPE {
   let ret = ATTACHMENT_RENAME_TYPE.ATTACHMENT_RENAME_TYPE_NULL;
@@ -307,6 +322,15 @@ export function needToRename(settings: AttachmentPathSettings, attachPath: strin
   return false;
 }
 
+/**
+ * Return the best matched override settings for the file/folder
+ * @param settings plugin setting
+ * @param file file need to get setting
+ * @param oldPath old path of the file, it it's be renamed (option)
+ * @returns { settingPath: string; setting: AttachmentPathSettings }, the best matched setting, 
+ * where settingPath is the relate path of this setting, it should be same with input path or is the 
+ * subpath of the settingPath.
+ */
 export function getOverrideSetting(
   settings: AttachmentManagementPluginSettings,
   file: TAbstractFile,
@@ -367,7 +391,14 @@ export function getOverrideSetting(
   return { settingPath: "", setting: settings.attachPath };
 }
 
-export function updateOverrideSetting(settings: AttachmentManagementPluginSettings, file: TAbstractFile, oldPath: string = "") {
+/**
+ * Update the override setting of the renamed file
+ * @param settings plugin setting
+ * @param file renamed file
+ * @param oldPath old path of the renamed file
+ * @returns
+ */
+export function updateOverrideSetting(settings: AttachmentManagementPluginSettings, file: TAbstractFile, oldPath: string) {
   const keys = Object.keys(settings.overridePath);
   if (keys.length === 0 || file.path === oldPath) {
     return;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -335,13 +335,17 @@ export function getOverrideSetting(
       if (overridePath === filePath && overrideSetting.type === SETTINGS_TYPE_FILE) {
         // best match
         return { settingPath: overridePath, setting: overrideSetting };
-      } else if (filePath.startsWith(overridePath) && overrideSetting.type === SETTINGS_TYPE_FOLDER) {
+      } else if (filePath.startsWith(overridePath) && filePath.charAt(overridePath.length) === "/" && overrideSetting.type === SETTINGS_TYPE_FOLDER) {
+        // parent path
+        // TODO: reimplement the method to check whether the overridePath is a parent path of filePath
         candidates[overridePath] = overrideSetting;
       }
     } else {
       if (overridePath === filePath && overrideSetting.type === SETTINGS_TYPE_FOLDER) {
+        // best match
         return { settingPath: overridePath, setting: overrideSetting };
-      } else if (filePath.startsWith(overridePath) && overrideSetting.type === SETTINGS_TYPE_FOLDER) {
+      } else if (filePath.startsWith(overridePath) && filePath.charAt(overridePath.length) === "/" && overrideSetting.type === SETTINGS_TYPE_FOLDER) {
+        // parent path
         candidates[overridePath] = overrideSetting;
       }
     }


### PR DESCRIPTION
This pull request implemented the feature that mentioned by issues  [[FR] Different settings for different folder](https://github.com/trganda/obsidian-attachment-management/issues/1).

## Overriding Setting

Your can set the attachment path setting for file or folder. The priority of these setting are:

```
file setting > most close parent folder setting > global setting
```

If you want to reset the setting of files or folder to the global setting, use the command `Reset Override Setting` or the `Reset` button of override setting panel. By the way, **the reset will only working on each file or folder that you have set on**. The more appropriate method to handle the reset will be add in future.

### Usage

- Open command palette and input `Override Setting` (only work for active file)
- Right click the folder or click the `Override attachment setting` in editor's more options

![image](https://github.com/trganda/obsidian-attachment-management/assets/62204882/651b9f88-6fec-4f93-b6eb-48ef164840e8)

And reset the setting of notes file or folder by

- Open command palette and input `Override Setting` (only work for active file)
- Click the reset button in `Override Setting`

![image](https://github.com/trganda/obsidian-attachment-management/assets/62204882/3fb3b9d0-80de-4888-a924-c4c77d32fa9e)