### PR TITLE
feat: add webp image support and parent as a variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Obsidian Attachment Management
 
-This plugin support to more flexibly to setting your attachment location with variable `${notepath}`, `${notename}`, `${date}`.
+This plugin supports more flexibly to setting your attachment location with variable like `${notepath}`, `${notename}` and `${date}`.
 
 ## Features
 
-This plugin currently support:
+This plugin currently supports:
 
 - [x] Setting the attachment location with `${notepath}`, `${notename}`, `${date}`
 - [x] Auto-rename the attachment when paste file to `markdown` or `canvas`
@@ -24,14 +24,13 @@ This plugin currently support:
 
 ## Settings
 
-The path of attachment was compose of three part
+The path of attachment is composed of three parts :
 
 ```
 {root path}/{attachment path}/{attachment name}.extension
 ```
 
-And your can use the variables below to config
-
+And you can use the variables below to config:
 - `${notepath}`: file path of the `markdown` or `canvas` file under the vault root.
 - `${notename}`: file name of the `markdown` or `canvas` file (not include file extension).
 - `${date}`: date time format by [Moment format options](https://momentjscom.readthedocs.io/en/latest/moment/04-displaying/01-format)
@@ -50,7 +49,12 @@ It can be set use the config of obsidian in `Files & Links`, or reset in this op
 
 ### Attachment Path
 
-A sub-folder to place attachment under the `{root path}`, available variables `${notename}` and `${notepath}`, default value `${notepath}/${notename}`.
+A sub-folder to place attachment under the `{root path}`, available variables :
+- `${notename}` : The note name of the `markdown` or `canvas` file where the attachment be placed.
+- `${notepath}` : The note path of the `markdown` or `canvas` file where the attachment be placed.
+- `${parent}` : The **parent** folder name of the `markdown` or `canvas` file where the attachment be placed.
+
+Default value `${notepath}/${notename}`.
 
 ### Attachment Format
 
@@ -78,15 +82,15 @@ Automatically rename the attachment folder/filename when you rename the folder/f
 
 Install and enable the plugin, after configure you can paste or drop attachment file as usually and it will be auto rename.
 
-This plugin support a command `Rearrange Linked Attachments`, if you run this command, it will rename all attachment that has bee linked in `markdown` or `canvas` file as you configured.
+This plugin supports a command `Rearrange Linked Attachments`. If you run this command, it will rename all attachment that has been linked in `markdown` or `canvas` file as you configured.
 
 ![SCR-20230511-rrtk](./images/SCR-20230511-rrtk.png)
 
-~~**Notice** The `Rearrange Linked Attachments` was currently a experimental feature, if you want to try out, it's better to backup your files at first.~~
+~~**Notice** The `Rearrange Linked Attachments` was currently a experimental feature, if you want to try out, it's better to back up your files at first.~~
 
 ### Overriding Setting
 
-Your can set the attachment path setting for file or folder. The priority of these setting are:
+You can set the attachment path setting for file or folder. The priority of these setting are:
 
 ```
 file setting > most close parent folder setting > global setting
@@ -96,7 +100,7 @@ If you want to reset the setting of files or folder to the global setting, use t
 
 ### Known Issues
 
-- No support for processing duplicated file name right now (in develop).
+- No support for processing duplicated file name right now (in develop). In backup, you could use the data variable [`x`](https://momentjscom.readthedocs.io/en/latest/moment/04-displaying/01-format/) to use Unix timestamp with millisecond as filename (it will prevent duplicated filename).
 - When drop a file in `canvas`, it's will delay to show the updated link/filename.
 
 ![Screen Recording](./images/canvas_drop_delay.gif)

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -6,6 +6,7 @@ export type RenameEventType = typeof RENAME_EVENT_TYPE_FOLDER | typeof RENAME_EV
 export const SETTINGS_VARIABLES_DATES = "${date}";
 export const SETTINGS_VARIABLES_NOTEPATH = "${notepath}";
 export const SETTINGS_VARIABLES_NOTENAME = "${notename}";
+export const SETTINGS_VARIABLES_PARENTFILE = "${parent}";
 export const SETTINGS_ROOT_OBSFOLDER = "obsFolder";
 export const SETTINGS_ROOT_INFOLDER = "inFolderBelow";
 export const SETTINGS_ROOT_NEXTTONOTE = "nextToNote";

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,10 @@
-import { FileSystemAdapter, ListedFiles, normalizePath, Notice, Plugin, TAbstractFile, TextFileView, TFile, TFolder } from "obsidian";
+import { ListedFiles, normalizePath, Notice, Plugin, TAbstractFile, TextFileView, TFile, TFolder } from "obsidian";
 import { AttachmentManagementPluginSettings, AttachmentPathSettings, DEFAULT_SETTINGS, SETTINGS_TYPE_FILE, SETTINGS_TYPE_FOLDER, SettingTab } from "./settings";
 import {
   ATTACHMENT_RENAME_TYPE,
   attachRenameType,
   debugLog,
-  getOverrideSetting,
+  getOverrideSetting, getParentFolder,
   isAttachment,
   isCanvasFile,
   isImage,
@@ -12,7 +12,7 @@ import {
   isPastedImage,
   stripPaths,
   testExcludeExtension,
-  updateOverrideSetting,
+  updateOverrideSetting
 } from "./utils";
 import {
   RENAME_EVENT_TYPE_FILE,
@@ -284,9 +284,10 @@ export default class AttachmentManagementPlugin extends Plugin {
     debugLog("Old Note Path:", oldNotePath);
     debugLog("Old Note Name:", oldNoteName);
 
+    const {parentPath, parentName} = getParentFolder(rf);
     // generate old attachment path
     const oldAttachPath = this.getAttachmentPath(oldNoteName, oldNotePath, setting, oldNoteParent);
-    const newAttachPath = this.getAttachmentPath(rf.basename, rf.parent?.path as string, setting, rf.parent?.parent?.name as string);
+    const newAttachPath = this.getAttachmentPath(rf.basename, parentPath, setting, parentName);
 
     debugLog("Old Attachment Path:", oldAttachPath);
     debugLog("New Attachment Path:", newAttachPath);
@@ -381,8 +382,11 @@ export default class AttachmentManagementPlugin extends Plugin {
 
     debugLog("Active File Path", activeFile.path);
 
+    const {parentPath, parentName} = getParentFolder(activeFile);
+    debugLog("Parent Path:", parentPath);
+    
     // TODO: what if activeFile.parent was undefined
-    const attachPath = this.getAttachmentPath(activeFile.basename, activeFile.parent?.path as string, setting, activeFile.parent?.name as string);
+    const attachPath = this.getAttachmentPath(activeFile.basename, parentPath, setting, parentName);
     const attachName = this.getPastedImageFileName(activeFile.basename, setting) + "." + file.extension;
 
     debugLog("New Path of File:", path.join(attachPath, attachName));
@@ -479,7 +483,7 @@ export default class AttachmentManagementPlugin extends Plugin {
    * @param parentFolderBasename
    * @returns attachment path
    */
-  getAttachmentPath(noteName: string, notePath: string, setting: AttachmentPathSettings = this.settings.attachPath, parentFolderBasename=""): string {
+  getAttachmentPath(noteName: string, notePath: string, setting: AttachmentPathSettings = this.settings.attachPath, parentFolderBasename: string): string {
     const root = this.getRootPath(notePath, setting);
     const attachPath = path.join(
       root,

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ import {
   SETTINGS_VARIABLES_DATES,
   SETTINGS_VARIABLES_NOTENAME,
   SETTINGS_VARIABLES_NOTEPATH,
+  SETTINGS_VARIABLES_PARENTFILE
 } from "./constant";
 import { OverrideModal } from "./override";
 import { path } from "./path";
@@ -277,13 +278,15 @@ export default class AttachmentManagementPlugin extends Plugin {
     const oldNotePath = path.dirname(oldPath);
     const oldNoteExtension = path.extname(oldPath);
     const oldNoteName = path.basename(oldPath, oldNoteExtension);
-
+    //generate parent of oldnotepath, last of the oldNotePath
+    const oldNoteParent = path.basename(path.dirname(oldPath));
+    
     debugLog("Old Note Path:", oldNotePath);
     debugLog("Old Note Name:", oldNoteName);
 
     // generate old attachment path
-    const oldAttachPath = this.getAttachmentPath(oldNoteName, oldNotePath, setting);
-    const newAttachPath = this.getAttachmentPath(rf.basename, rf.parent?.path as string, setting);
+    const oldAttachPath = this.getAttachmentPath(oldNoteName, oldNotePath, setting, oldNoteParent);
+    const newAttachPath = this.getAttachmentPath(rf.basename, rf.parent?.path as string, setting, rf.parent?.parent?.name as string);
 
     debugLog("Old Attachment Path:", oldAttachPath);
     debugLog("New Attachment Path:", newAttachPath);
@@ -379,12 +382,12 @@ export default class AttachmentManagementPlugin extends Plugin {
     debugLog("Active File Path", activeFile.path);
 
     // TODO: what if activeFile.parent was undefined
-    const attachPath = this.getAttachmentPath(activeFile.basename, activeFile.parent?.path as string, setting);
+    const attachPath = this.getAttachmentPath(activeFile.basename, activeFile.parent?.path as string, setting, activeFile.parent?.name as string);
     const attachName = this.getPastedImageFileName(activeFile.basename, setting) + "." + file.extension;
 
     debugLog("New Path of File:", path.join(attachPath, attachName));
 
-    this.renameFile(file, attachPath, attachName, activeFile.path, ext, true);
+    await this.renameFile(file, attachPath, attachName, activeFile.path, ext, true);
   }
 
   /**
@@ -473,13 +476,16 @@ export default class AttachmentManagementPlugin extends Plugin {
    * @param noteName - basename (without extension) of note
    * @param notePath - path of note
    * @param setting
+   * @param parentFolderBasename
    * @returns attachment path
    */
-  getAttachmentPath(noteName: string, notePath: string, setting: AttachmentPathSettings = this.settings.attachPath): string {
+  getAttachmentPath(noteName: string, notePath: string, setting: AttachmentPathSettings = this.settings.attachPath, parentFolderBasename=""): string {
     const root = this.getRootPath(notePath, setting);
     const attachPath = path.join(
       root,
-      setting.attachmentPath.replace(`${SETTINGS_VARIABLES_NOTEPATH}`, notePath).replace(`${SETTINGS_VARIABLES_NOTENAME}`, noteName)
+      setting.attachmentPath.replace(`${SETTINGS_VARIABLES_NOTEPATH}`, notePath)
+        .replace(`${SETTINGS_VARIABLES_NOTENAME}`, noteName)
+        .replace(`${SETTINGS_VARIABLES_PARENTFILE}`, parentFolderBasename)
     );
     return normalizePath(attachPath);
   }

--- a/src/override.ts
+++ b/src/override.ts
@@ -7,7 +7,7 @@ import {
   SETTINGS_ROOT_NEXTTONOTE,
   SETTINGS_VARIABLES_NOTEPATH,
   SETTINGS_VARIABLES_NOTENAME,
-  SETTINGS_VARIABLES_DATES,
+  SETTINGS_VARIABLES_DATES, SETTINGS_VARIABLES_PARENTFILE
 } from "./constant";
 import AttachmentManagementPlugin from "./main";
 
@@ -67,20 +67,20 @@ export class OverrideModal extends Modal {
           .setPlaceholder(DEFAULT_SETTINGS.attachPath.attachmentRoot)
           .setValue(this.setting.attachmentRoot)
           .onChange(async (value) => {
-            console.log("Attachment root: " + value);
+            debugLog("Attachment root: " + value);
             this.setting.attachmentRoot = value;
           })
       );
 
     new Setting(contentEl)
       .setName("Attachment path")
-      .setDesc(`Path of new attachment in root folder, available variables ${SETTINGS_VARIABLES_NOTEPATH} and ${SETTINGS_VARIABLES_NOTENAME}`)
+      .setDesc(`Path of new attachment in root folder, available variables ${SETTINGS_VARIABLES_NOTEPATH}, ${SETTINGS_VARIABLES_NOTENAME} and ${SETTINGS_VARIABLES_PARENTFILE}`)
       .addText((text) =>
         text
           .setPlaceholder(DEFAULT_SETTINGS.attachPath.attachmentPath)
           .setValue(this.setting.attachmentPath)
           .onChange(async (value) => {
-            console.log("Attachment path: " + value);
+            debugLog("Attachment path: " + value);
             this.setting.attachmentPath = value;
           })
       );
@@ -93,7 +93,7 @@ export class OverrideModal extends Modal {
           .setPlaceholder(DEFAULT_SETTINGS.attachPath.attachFormat)
           .setValue(this.setting.attachFormat)
           .onChange(async (value: string) => {
-            console.log("Attachment format: " + value);
+            debugLog("Attachment format: " + value);
             this.setting.attachFormat = value;
           })
       );

--- a/src/path.ts
+++ b/src/path.ts
@@ -33,7 +33,7 @@ export const path = {
   },
 
   // returns the last part of a path, e.g. 'foo.jpg'
-  basename(filepath: string, extension: string = ""): string {
+  basename(filepath: string, extension = ""): string {
     const sp = filepath.split("/");
     const filename = sp[sp.length - 1];
     if (extension !== "") {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,10 +4,12 @@ import {
   SETTINGS_ROOT_OBSFOLDER,
   SETTINGS_VARIABLES_NOTEPATH,
   SETTINGS_VARIABLES_NOTENAME,
+  SETTINGS_VARIABLES_PARENTFILE,
   SETTINGS_VARIABLES_DATES,
   SETTINGS_ROOT_INFOLDER,
   SETTINGS_ROOT_NEXTTONOTE,
 } from "./constant";
+import { debugLog } from "./utils";
 
 export type SETTINGS_TYPE = string;
 
@@ -79,7 +81,7 @@ export class SettingTab extends PluginSettingTab {
         }
       }
       if (el.getAttr("class")?.includes("exclude_extension_pattern")) {
-        if (this.plugin.settings.handleAll === false) {
+        if (!this.plugin.settings.handleAll) {
           el.hide();
         } else {
           el.show();
@@ -122,7 +124,7 @@ export class SettingTab extends PluginSettingTab {
           .setPlaceholder(DEFAULT_SETTINGS.attachPath.attachmentRoot)
           .setValue(this.plugin.settings.attachPath.attachmentRoot)
           .onChange(async (value) => {
-            console.log("Attachment root: " + value);
+            debugLog("Attachment root: " + value);
             this.plugin.settings.attachPath.attachmentRoot = value;
             await this.plugin.saveSettings();
           })
@@ -130,13 +132,13 @@ export class SettingTab extends PluginSettingTab {
 
     new Setting(containerEl)
       .setName("Attachment path")
-      .setDesc(`Path of new attachment in root folder, available variables ${SETTINGS_VARIABLES_NOTEPATH} and ${SETTINGS_VARIABLES_NOTENAME}`)
+      .setDesc(`Path of new attachment in root folder, available variables ${SETTINGS_VARIABLES_NOTEPATH}, ${SETTINGS_VARIABLES_NOTENAME}, ${SETTINGS_VARIABLES_PARENTFILE}`)
       .addText((text) =>
         text
           .setPlaceholder(DEFAULT_SETTINGS.attachPath.attachmentPath)
           .setValue(this.plugin.settings.attachPath.attachmentPath)
           .onChange(async (value) => {
-            console.log("Attachment path: " + value);
+            debugLog("Attachment path: " + value);
             this.plugin.settings.attachPath.attachmentPath = value;
             await this.plugin.saveSettings();
           })
@@ -150,7 +152,7 @@ export class SettingTab extends PluginSettingTab {
           .setPlaceholder(DEFAULT_SETTINGS.attachPath.attachFormat)
           .setValue(this.plugin.settings.attachPath.attachFormat)
           .onChange(async (value: string) => {
-            console.log("Attachment format: " + value);
+            debugLog("Attachment format: " + value);
             this.plugin.settings.attachPath.attachFormat = value;
             await this.plugin.saveSettings();
           })
@@ -172,7 +174,7 @@ export class SettingTab extends PluginSettingTab {
           .setPlaceholder(DEFAULT_SETTINGS.dateFormat)
           .setValue(this.plugin.settings.dateFormat)
           .onChange(async (value) => {
-            console.log("Date format: " + value);
+            debugLog("Date format: " + value);
             this.plugin.settings.dateFormat = value;
             await this.plugin.saveSettings();
           })
@@ -183,7 +185,7 @@ export class SettingTab extends PluginSettingTab {
       .setDesc("By default, only auto-rename the image file, if enable this option, all created file (except `md` or `canvas`) will be renamed automatically")
       .addToggle((toggle) =>
         toggle.setValue(this.plugin.settings.handleAll).onChange(async (value) => {
-          console.log("Handle All Create Attachment: " + value);
+          debugLog("Handle All Create Attachment: " + value);
           this.plugin.settings.handleAll = value;
           this.displaySw(containerEl);
           await this.plugin.saveSettings();
@@ -209,7 +211,7 @@ export class SettingTab extends PluginSettingTab {
       .setDesc("Automatically rename the attachment folder/filename when you rename the folder/filename where the corresponding md/canvas file be placed.")
       .addToggle((toggle) =>
         toggle.setValue(this.plugin.settings.autoRenameAttachment).onChange(async (value) => {
-          console.log("Automatically rename attachment folder: " + value);
+          debugLog("Automatically rename attachment folder: " + value);
           this.plugin.settings.autoRenameAttachment = value;
           await this.plugin.saveSettings();
         })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,9 +15,9 @@ export enum ATTACHMENT_RENAME_TYPE {
 }
 
 const PASTED_IMAGE_PREFIX = "Pasted image ";
-const imageRegex = /.*(jpe?g|png|gif|svg|bmp|eps)/i;
+const imageRegex = /.*(jpe?g|png|gif|svg|bmp|eps|webp)/i;
 const bannerRegex = /!\[\[(.*?)\]\]/i;
-const imageExtensions: Set<string> = new Set(["jpeg", "jpg", "png", "gif", "svg", "bmp", "eps"]);
+const imageExtensions: Set<string> = new Set(["jpeg", "jpg", "png", "gif", "svg", "bmp", "eps", "webp"]);
 
 export const DEBUG = !(process.env.BUILD_ENV === "production");
 if (DEBUG) console.log("DEBUG is enabled");
@@ -37,17 +37,12 @@ export const blobToArrayBuffer = (blob: Blob) => {
 };
 
 export function isMarkdownFile(extension: string): boolean {
-  if (extension === "md") {
-    return true;
-  }
-  return false;
+  return extension === "md";
+  
 }
 
 export function isCanvasFile(extension: string): boolean {
-  if (extension === "canvas") {
-    return true;
-  }
-  return false;
+  return extension === "canvas";
 }
 
 export function isPastedImage(file: TAbstractFile): boolean {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -268,7 +268,10 @@ export function attachRenameType(setting: AttachmentPathSettings): ATTACHMENT_RE
   let ret = ATTACHMENT_RENAME_TYPE.ATTACHMENT_RENAME_TYPE_NULL;
 
   if (setting.attachFormat.includes(SETTINGS_VARIABLES_NOTENAME) || setting.attachFormat.includes(SETTINGS_VARIABLES_DATES)) {
-    if (setting.attachmentPath.includes(SETTINGS_VARIABLES_NOTENAME) || setting.attachmentPath.includes(SETTINGS_VARIABLES_NOTEPATH)) {
+    if (setting.attachmentPath.includes(SETTINGS_VARIABLES_NOTENAME)
+      || setting.attachmentPath.includes(SETTINGS_VARIABLES_NOTEPATH)
+      || setting.attachmentPath.includes(SETTINGS_VARIABLES_PARENTFILE)
+    ) {
       ret = ATTACHMENT_RENAME_TYPE.ATTACHMENT_RENAME_TYPE_BOTH;
     } else {
       ret = ATTACHMENT_RENAME_TYPE.ATTACHMENT_RENAME_TYPE_FILE;
@@ -409,4 +412,15 @@ export function updateOverrideSetting(settings: AttachmentManagementPluginSettin
       return;
     }
   }
+}
+
+export function getParentFolder(rf: TFile) {
+  const parent = rf.parent;
+  let parentPath = "/";
+  let parentName = "/";
+  if (parent) {
+    parentPath = parent.path;
+    parentName = parent.name;
+  }
+  return { parentPath, parentName };
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import { App, TAbstractFile, TFile, TFolder } from "obsidian";
 import { LinkMatch, getAllLinkMatchesInFile } from "./linkDetector";
 import { AttachmentManagementPluginSettings, AttachmentPathSettings, SETTINGS_TYPE_FILE, SETTINGS_TYPE_FOLDER } from "./settings";
-import { SETTINGS_VARIABLES_DATES, SETTINGS_VARIABLES_NOTENAME, SETTINGS_VARIABLES_NOTEPATH } from "./constant";
+import { SETTINGS_VARIABLES_DATES, SETTINGS_VARIABLES_NOTENAME, SETTINGS_VARIABLES_NOTEPATH, SETTINGS_VARIABLES_PARENTFILE } from "./constant";
 
 export enum ATTACHMENT_RENAME_TYPE {
   // need to rename the attachment folder and file name
@@ -273,10 +273,8 @@ export function attachRenameType(setting: AttachmentPathSettings): ATTACHMENT_RE
     } else {
       ret = ATTACHMENT_RENAME_TYPE.ATTACHMENT_RENAME_TYPE_FILE;
     }
-  } else {
-    if (setting.attachmentPath.includes(SETTINGS_VARIABLES_NOTENAME) || setting.attachmentPath.includes(SETTINGS_VARIABLES_NOTEPATH)) {
+  } else if (setting.attachmentPath.includes(SETTINGS_VARIABLES_NOTENAME) || setting.attachmentPath.includes(SETTINGS_VARIABLES_NOTEPATH) || setting.attachmentPath.includes(SETTINGS_VARIABLES_PARENTFILE)) {
       ret = ATTACHMENT_RENAME_TYPE.ATTACHMENT_RENAME_TYPE_FOLDER;
-    }
   }
 
   return ret;


### PR DESCRIPTION
Spotted that `webp` wasn't in image support, so I added it :D 

(cf https://help.obsidian.md/Advanced+topics/Accepted+file+formats)

I also simplified some expression 