### PR TITLE
fix: typo error and redundant header of settings

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -79,7 +79,7 @@ export default class AttachmentManagementPlugin extends Plugin {
 
     this.addCommand({
       id: "reset-override-setting",
-      name: "Reset Overrode Setting",
+      name: "Reset Override Setting",
       checkCallback: (checking: boolean) => {
         const file = this.getActiveFile();
         if (file) {

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -96,10 +96,6 @@ export class SettingTab extends PluginSettingTab {
 
     containerEl.empty();
 
-    containerEl.createEl("h2", {
-      text: "Settings for Attachment Management.",
-    });
-
     new Setting(containerEl)
       .setName("Root path to save new attachments")
       .setDesc("Select root path for all new attachments")


### PR DESCRIPTION
Fix some problem mentioned in https://github.com/obsidianmd/obsidian-releases/pull/1947#issuecomment-1584348030

- Typo error of "overrode" -> "override"
- Remoe heading of basic setting as refered [plugin guidelines - UI text](https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#UI+text)