### PR TITLE
Feat: Add Exclude Paths Setting

### DIFF
--- a/src/arrange.ts
+++ b/src/arrange.ts
@@ -1,4 +1,4 @@
-import { App, TFile, TFolder } from "obsidian";
+import { App, Notice, TFile, TFolder } from "obsidian";
 import { path } from "./lib/path";
 import { debugLog } from "./log";
 import { getOverrideSetting } from "./override";
@@ -146,6 +146,7 @@ export class ArrangeHandler {
       if (file) {
         if ((file.parent && isExcluded(file.parent.path, this.settings)) || isAttachment(this.settings, file)) {
           allFiles = [];
+          new Notice(`${file.path} was excluded, skipped`);
         } else {
           debugLog("getAttachmentsInVaultByLinks - active file:", file.path);
           allFiles = [file];

--- a/src/create.ts
+++ b/src/create.ts
@@ -6,6 +6,7 @@ import { AttachmentManagementPluginSettings, DEFAULT_SETTINGS } from "./settings
 import { getActiveFile, getActiveView } from "./commons";
 import { getOverrideSetting } from "./override";
 import { getMetadata } from "./metadata";
+import { isExcluded } from "./exclude";
 
 export class CreateHandler {
   readonly app: App;
@@ -31,6 +32,13 @@ export class CreateHandler {
       new Notice("Error: no active file found.");
       return;
     }
+
+    debugLog("processAttach - parent:", activeFile.parent?.path);
+    if ((activeFile.parent && isExcluded(activeFile.parent.path, this.settings))) {
+      debugLog("processAttach - not a file or exclude path:", activeFile.path);
+      return;
+    }
+
     const { setting } = getOverrideSetting(this.settings, activeFile);
 
     debugLog("processAttach - active file path", activeFile.path);

--- a/src/create.ts
+++ b/src/create.ts
@@ -36,6 +36,7 @@ export class CreateHandler {
     debugLog("processAttach - parent:", activeFile.parent?.path);
     if ((activeFile.parent && isExcluded(activeFile.parent.path, this.settings))) {
       debugLog("processAttach - not a file or exclude path:", activeFile.path);
+      new Notice(`${activeFile.path} was excluded, skipped`);
       return;
     }
 

--- a/src/exclude.ts
+++ b/src/exclude.ts
@@ -1,0 +1,23 @@
+import { debugLog } from "./log";
+import { AttachmentManagementPluginSettings } from "./settings/settings";
+
+export function isExcluded(path: string, settings: AttachmentManagementPluginSettings): boolean {
+
+  debugLog("excludePathsArray: ", settings.excludePathsArray);
+
+  for (const excludedPath of settings.excludePathsArray) {
+    if (excludedPath.length === 0) {
+      continue;
+    }
+    if (settings.excludeSubpaths && path.startsWith(excludedPath)) {
+      debugLog("isExcluded: ", path);
+      return true;
+    } else {
+      if (path === excludedPath) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,9 +62,16 @@ export default class AttachmentManagementPlugin extends Plugin {
         const file = getActiveFile(this.app);
 
         if (file) {
-          if ((file.parent && isExcluded(file.parent.path, this.settings)) || isAttachment(this.settings, file)) {
+          if (isAttachment(this.settings, file)) {
+            new Notice(`${file.path} is an attachment, skipped`);
             return true;
           }
+
+          if (file.parent && isExcluded(file.parent.path, this.settings)) {
+            new Notice(`${file.path} was excluded, skipped`);
+            return true;
+          }
+
           if (!checking) {
             const { setting } = getOverrideSetting(this.settings, file);
             const fileSetting = Object.assign({}, setting);
@@ -82,9 +89,16 @@ export default class AttachmentManagementPlugin extends Plugin {
       checkCallback: (checking: boolean) => {
         const file = getActiveFile(this.app);
         if (file) {
-          if ((file.parent && isExcluded(file.parent.path, this.settings)) || isAttachment(this.settings, file)) {
+          if (isAttachment(this.settings, file)) {
+            new Notice(`${file.path} is an attachment, skipped`);
             return true;
           }
+
+          if (file.parent && isExcluded(file.parent.path, this.settings)) {
+            new Notice(`${file.path} was excluded, skipped`);
+            return true;
+          }
+
           if (!checking) {
             delete this.settings.overridePath[file.path];
             this.saveSettings();
@@ -182,6 +196,7 @@ export default class AttachmentManagementPlugin extends Plugin {
         if (file instanceof TFile) {
           if (file.parent && isExcluded(file.parent.path, this.settings)) {
             debugLog("rename - exclude path:", file.parent.path);
+            new Notice(`${file.path} was excluded, skipped`);
             return;
           }
           // if the renamed file was a attachment, skip

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -1,4 +1,4 @@
-import { App, PluginSettingTab, Setting, TextAreaComponent } from "obsidian";
+import { App, MomentFormatComponent, PluginSettingTab, Setting, TextAreaComponent } from "obsidian";
 import AttachmentManagementPlugin from "../main";
 import {
   SETTINGS_ROOT_OBSFOLDER,
@@ -181,21 +181,21 @@ export class SettingTab extends PluginSettingTab {
           });
         })
       )
-      .addText((text) =>
-        text
+      .addMomentFormat((component: MomentFormatComponent) => {
+        component
           .setPlaceholder(DEFAULT_SETTINGS.dateFormat)
           .setValue(this.plugin.settings.dateFormat)
           .onChange(async (value) => {
             debugLog("setting - date format:" + value);
             this.plugin.settings.dateFormat = value;
             await this.plugin.saveSettings();
-          })
-      );
+          });
+      });
 
     new Setting(containerEl)
       .setName("Handle all attachments")
       .setDesc(
-        "By default, only auto-rename the image file, if enable this option, all created file (except `md` or `canvas`) will be renamed automatically"
+        "By default, only auto-rename the image file, if enable this option, all created file (except 'md' or 'canvas') will be renamed automatically"
       )
       .addToggle((toggle) =>
         toggle.setValue(this.plugin.settings.handleAll).onChange(async (value) => {
@@ -212,6 +212,7 @@ export class SettingTab extends PluginSettingTab {
         `This option is only useful when "Handle all attachments" is enabled.	Write a Regex pattern to exclude certain extensions from being handled.`
       )
       .setClass("exclude_extension_pattern")
+      .setClass("attach_management_sub_setting")
       .addText((text) =>
         text
           .setPlaceholder("pdf|docx?|xlsx?|pptx?|zip|rar")
@@ -238,7 +239,7 @@ export class SettingTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName("Excluded paths")
       .setDesc(
-        `Provide the full path of the folder names (Case Sensitive) divided by semicolon (;) to be excluded from renaming.`
+        `Provide the full path of the folder names (case sensitive and without leading slash '/') divided by semicolon (;) to be excluded from renaming.`
       )
       .addTextArea((component: TextAreaComponent) => {
         component.setValue(this.plugin.settings.excludedPaths).onChange(async (value) => {

--- a/styles.css
+++ b/styles.css
@@ -6,3 +6,10 @@ available in the app when your plugin is enabled.
 If your plugin does not need CSS, delete this file.
 
 */
+.attach_management_sub_setting {
+  padding-left: 2em;
+}
+.attach_management_sub_setting + .attach_management_sub_setting {
+  padding-left: 0;
+  margin-left: 2em;
+}


### PR DESCRIPTION
PR for https://github.com/trganda/obsidian-attachment-management/issues/33

Change:

- You can now add the path of folder to "Exclude paths" to prevent the file under the folder be process by this plugin.
- By default, the "Exclude paths" will work on current folder, you can toggle "Exclude subpaths" to exclude subpaths also.