### PR TITLE
fix: multi file created without update link

### DIFF
--- a/src/create.ts
+++ b/src/create.ts
@@ -86,14 +86,11 @@ export class CreateHandler {
     const oldPath = file.path;
     const oldName = file.name;
 
-    try {
-      // this api will not update the link automatically on `create` event
-      await this.app.fileManager.renameFile(file, dst);
-      new Notice(`Renamed ${oldName} to ${attachName}.`);
-    } catch (err) {
-      new Notice(`Failed to rename ${file.path} to ${dst}`);
-      throw err;
-    }
+    // this api will not update the link automatically on `create` event
+    // forgive using to rename, refer: https://github.com/trganda/obsidian-attachment-management/issues/46
+    //   await this.app.fileManager.renameFile(file, dst);
+    await this.app.vault.adapter.rename(file.path, dst);
+    new Notice(`Renamed ${oldName} to ${attachName}.`);
 
     if (!updateLink) {
       return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -128,14 +128,14 @@ export default class AttachmentManagementPlugin extends Plugin {
 
     this.registerEvent(
       // not working while drop file to text view
-      this.app.vault.on("create", (file: TAbstractFile) => {
+      this.app.vault.on("create", async (file: TAbstractFile) => {
         debugLog("on create event - file:", file.path);
         // only processing create of file, ignore folder creation
         if (!(file instanceof TFile)) {
           return;
         }
 
-        this.app.workspace.onLayoutReady(() => {
+        this.app.workspace.onLayoutReady(async () => {
           // if the file is created more than 1 second ago, the event is most likely be fired by copy file to
           // vault folder without using obsidian (e.g. file manager of op system), we should ignore it.
           const timeGapMs = new Date().getTime() - file.stat.mtime;
@@ -150,7 +150,7 @@ export default class AttachmentManagementPlugin extends Plugin {
           const processor = new CreateHandler(this.app, this.settings);
           if (isImage(file.extension) || isPastedImage(file)) {
             debugLog("create - image", file);
-            processor.processAttach(file);
+            await processor.processAttach(file);
           } else {
             if (this.settings.handleAll) {
               debugLog("create - handleAll for file", file);
@@ -158,7 +158,7 @@ export default class AttachmentManagementPlugin extends Plugin {
                 debugLog("create - excluded file by extension", file);
                 return;
               }
-              processor.processAttach(file);
+              await processor.processAttach(file);
             }
           }
         });


### PR DESCRIPTION
Fix the problem mentioned in https://github.com/trganda/obsidian-attachment-management/issues/46

TL,DR

[DataAdapter.rename](https://github.com/obsidianmd/obsidian-api/blob/master/obsidian.d.ts#L1294C26-L1294C26) was better then [FileManager.renameFile(file, dst)](https://github.com/obsidianmd/obsidian-api/blob/master/obsidian.d.ts#L1294C12-L1294C12)