### PR TITLE
fix: no rename for no image extension

### DIFF
--- a/src/rename.ts
+++ b/src/rename.ts
@@ -143,7 +143,7 @@ export class RenameHandler {
       const fileExtension = path.extname(fileName);
       if (
         (this.settings.handleAll && testExcludeExtension(fileExtension, this.settings.excludeExtensionPattern)) ||
-        !isImage(fileExtension)
+        (!this.settings.handleAll && !isImage(fileExtension))
       ) {
         debugLog("renameFiles - no handle extension:", fileExtension);
         continue;


### PR DESCRIPTION
fix the bug mentioned in https://github.com/trganda/obsidian-attachment-management/issues/51