### PR TITLE
fix: rename not working while quickly switch tab

### DIFF
--- a/src/commons.ts
+++ b/src/commons.ts
@@ -65,7 +65,8 @@ export function getRootPath(notePath: string, setting: AttachmentPathSettings | 
 }
 
 export async function checkEmptyFolder(adapter: DataAdapter, path: string): Promise<boolean> {
-    if (!adapter.exists(path, true)) {
+    const exist = await adapter.exists(path, true);
+    if (!exist) {
         return true;
     }
 
@@ -75,9 +76,9 @@ export async function checkEmptyFolder(adapter: DataAdapter, path: string): Prom
     }
 
     if (data.folders.length > 0) {
-        data.folders.forEach((folder) => {
-            return checkEmptyFolder(adapter, folder)
-        })
+        for (let i = 0; i < data.folders.length; i++) {
+            return checkEmptyFolder(adapter, data.folders[i]);
+        }
     }
 
     return true;

--- a/src/create.ts
+++ b/src/create.ts
@@ -9,7 +9,6 @@ import { isExcluded } from "./exclude";
 import { getExtensionOverrideSetting } from "./model/extensionOverride";
 import { MD5, isImage, isPastedImage } from "./utils";
 import { saveOriginalName } from "./lib/originalStorage";
-import { getActiveFile } from "./commons";
 
 export class CreateHandler {
     readonly plugin: Plugin;
@@ -28,13 +27,6 @@ export class CreateHandler {
      * @returns - none
      */
     processAttach(attach: TFile, source: TFile) {
-        const activeFile = getActiveFile(this.app);
-        if (activeFile == undefined || activeFile != source) {
-            debugLog("Error: no active file found.");
-            return;
-        }
-        
-        debugLog("processAttach - parent:", source.parent?.path);
         if (source.parent && isExcluded(source.parent.path, this.settings)) {
             debugLog("processAttach - not a file or exclude path:", source.path);
             new Notice(`${source.path} was excluded, skipped`);

--- a/src/override.ts
+++ b/src/override.ts
@@ -185,7 +185,6 @@ export function updateOverrideSetting(
 export function deleteOverrideSetting(settings: AttachmentManagementPluginSettings, file: TAbstractFile): boolean {
     const keys = Object.keys(settings.overridePath);
     for (const key of keys) {
-        debugLog("deleteOverrideSetting - key:", key, file.path);
         if (file.path === key) {
             delete settings.overridePath[key];
             return true;


### PR DESCRIPTION
Bug fix:
- rename not working while quickly switch tab
- flaw implementation of empty folder checking