### PR TITLE
fix for slow startup issue #120

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -28,134 +28,137 @@ export default class AttachmentManagementPlugin extends Plugin {
 
         console.log(`Plugin loading: ${this.manifest.name} v.${this.manifest.version}`);
 
-        this.addCommand({
-            id: "attachment-management-rearrange-all-links",
-            name: "Rearrange all linked attachments",
-            callback: async () => {
-                new ConfirmModal(this).open();
-            },
-        });
+        this.app.workspace.onLayoutReady(() => {
 
-        this.addCommand({
-            id: "attachment-management-rearrange-active-links",
-            name: "Rearrange linked attachments",
-            callback: async () => {
-                new ArrangeHandler(this.settings, this.app, this).rearrangeAttachment("active").finally(() => {
-                    new Notice("Arrange completed");
-                });
-            },
-        });
+            console.log(`${this.manifest.name} got onLayoutReady`);
 
-        this.addCommand({
-            id: "override-setting",
-            name: "Overriding setting",
-            checkCallback: (checking: boolean) => {
-                const file = getActiveFile(this.app);
+            this.addCommand({
+                id: "attachment-management-rearrange-all-links",
+                name: "Rearrange all linked attachments",
+                callback: async () => {
+                    new ConfirmModal(this).open();
+                },
+            });
 
-                if (file) {
-                    if (isAttachment(this.settings, file)) {
-                        new Notice(`${file.path} is an attachment, skipped`);
-                        return true;
-                    }
+            this.addCommand({
+                id: "attachment-management-rearrange-active-links",
+                name: "Rearrange linked attachments",
+                callback: async () => {
+                    new ArrangeHandler(this.settings, this.app, this).rearrangeAttachment("active").finally(() => {
+                        new Notice("Arrange completed");
+                    });
+                },
+            });
 
-                    if (!checking) {
-                        if (file.parent && isExcluded(file.parent.path, this.settings)) {
-                            new Notice(`${file.path} was excluded, skipped`);
+            this.addCommand({
+                id: "override-setting",
+                name: "Overriding setting",
+                checkCallback: (checking: boolean) => {
+                    const file = getActiveFile(this.app);
+
+                    if (file) {
+                        if (isAttachment(this.settings, file)) {
+                            new Notice(`${file.path} is an attachment, skipped`);
                             return true;
                         }
-                        const { setting } = getOverrideSetting(this.settings, file);
-                        const fileSetting = Object.assign({}, setting);
-                        this.overrideConfiguration(file, fileSetting);
-                    }
-                    return true;
-                }
-                return false;
-            },
-        });
 
-        this.addCommand({
-            id: "reset-override-setting",
-            name: "Reset override setting",
-            checkCallback: (checking: boolean) => {
-                const file = getActiveFile(this.app);
-                if (file) {
-                    if (isAttachment(this.settings, file)) {
-                        new Notice(`${file.path} is an attachment, skipped`);
+                        if (!checking) {
+                            if (file.parent && isExcluded(file.parent.path, this.settings)) {
+                                new Notice(`${file.path} was excluded, skipped`);
+                                return true;
+                            }
+                            const { setting } = getOverrideSetting(this.settings, file);
+                            const fileSetting = Object.assign({}, setting);
+                            this.overrideConfiguration(file, fileSetting);
+                        }
                         return true;
                     }
+                    return false;
+                },
+            });
 
-                    if (!checking) {
-                        if (file.parent && isExcluded(file.parent.path, this.settings)) {
-                            new Notice(`${file.path} was excluded, skipped`);
+            this.addCommand({
+                id: "reset-override-setting",
+                name: "Reset override setting",
+                checkCallback: (checking: boolean) => {
+                    const file = getActiveFile(this.app);
+                    if (file) {
+                        if (isAttachment(this.settings, file)) {
+                            new Notice(`${file.path} is an attachment, skipped`);
                             return true;
                         }
-                        delete this.settings.overridePath[file.path];
-                        this.saveSettings();
-                        this.loadSettings();
-                        new Notice(`Reset attachment setting of ${file.path}`);
-                    }
-                    return true;
-                }
-                return false;
-            },
-        });
 
-        this.addCommand({
-            id: "attachment-management-clear-unused-originalname-storage",
-            name: "Clear unused original name storage",
-            callback: async () => {
-                const attachments = await new ArrangeHandler(this.settings, this.app, this).getAttachmentsInVault(
-                    this.settings,
-                    "links"
-                );
-                const storages: OriginalNameStorage[] = [];
-                for (const attachs of Object.values(attachments)) {
-                    for (const attach of attachs) {
-                        const link = decodeURI(attach);
-                        const linkFile = this.app.vault.getAbstractFileByPath(link);
-                        if (linkFile !== null && linkFile instanceof TFile) {
-                            const md5 = await MD5(this.app.vault.adapter, linkFile);
-                            const ret = this.settings.originalNameStorage.find((data) => data.md5 === md5);
-                            if (ret) {
-                                storages.filter((n) => n.md5 == md5).forEach((n) => storages.remove(n));
-                                storages.push(ret);
+                        if (!checking) {
+                            if (file.parent && isExcluded(file.parent.path, this.settings)) {
+                                new Notice(`${file.path} was excluded, skipped`);
+                                return true;
+                            }
+                            delete this.settings.overridePath[file.path];
+                            this.saveSettings();
+                            this.loadSettings();
+                            new Notice(`Reset attachment setting of ${file.path}`);
+                        }
+                        return true;
+                    }
+                    return false;
+                },
+            });
+
+            this.addCommand({
+                id: "attachment-management-clear-unused-originalname-storage",
+                name: "Clear unused original name storage",
+                callback: async () => {
+                    const attachments = await new ArrangeHandler(this.settings, this.app, this).getAttachmentsInVault(
+                        this.settings,
+                        "links"
+                    );
+                    const storages: OriginalNameStorage[] = [];
+                    for (const attachs of Object.values(attachments)) {
+                        for (const attach of attachs) {
+                            const link = decodeURI(attach);
+                            const linkFile = this.app.vault.getAbstractFileByPath(link);
+                            if (linkFile !== null && linkFile instanceof TFile) {
+                                const md5 = await MD5(this.app.vault.adapter, linkFile);
+                                const ret = this.settings.originalNameStorage.find((data) => data.md5 === md5);
+                                if (ret) {
+                                    storages.filter((n) => n.md5 == md5).forEach((n) => storages.remove(n));
+                                    storages.push(ret);
+                                }
                             }
                         }
                     }
-                }
-                debugLog("clearUnusedOriginalNameStorage - storage:", storages);
-                this.settings.originalNameStorage = storages;
-                await this.saveSettings();
-                this.loadSettings();
-            },
-        });
+                    debugLog("clearUnusedOriginalNameStorage - storage:", storages);
+                    this.settings.originalNameStorage = storages;
+                    await this.saveSettings();
+                    this.loadSettings();
+                },
+            });
 
-        this.registerEvent(
-            this.app.workspace.on("file-menu", async (menu, file) => {
-                if ((file.parent && isExcluded(file.parent.path, this.settings)) || isAttachment(this.settings, file)) {
-                    return;
-                }
-                menu.addItem((item) => {
-                    item.setTitle("Overriding attachment setting")
-                        .setIcon("image-plus")
-                        .onClick(async () => {
-                            const { setting } = getOverrideSetting(this.settings, file);
-                            const fileSetting = Object.assign({}, setting);
-                            await this.overrideConfiguration(file, fileSetting);
-                        });
-                });
-            })
-        );
+            this.registerEvent(
+                this.app.workspace.on("file-menu", async (menu, file) => {
+                    if ((file.parent && isExcluded(file.parent.path, this.settings)) || isAttachment(this.settings, file)) {
+                        return;
+                    }
+                    menu.addItem((item) => {
+                        item.setTitle("Overriding attachment setting")
+                            .setIcon("image-plus")
+                            .onClick(async () => {
+                                const { setting } = getOverrideSetting(this.settings, file);
+                                const fileSetting = Object.assign({}, setting);
+                                await this.overrideConfiguration(file, fileSetting);
+                            });
+                    });
+                })
+            );
 
-        this.registerEvent(
-            this.app.vault.on("create", async (file: TAbstractFile) => {
-                debugLog("on create event - file:", file.path);
-                // only processing create of file, ignore folder creation
-                if (!(file instanceof TFile)) {
-                    return;
-                }
+            this.registerEvent(
+                this.app.vault.on("create", async (file: TAbstractFile) => {
+                    debugLog("on create event - file:", file.path);
+                    // only processing create of file, ignore folder creation
+                    if (!(file instanceof TFile)) {
+                        return;
+                    }
 
-                this.app.workspace.onLayoutReady(async () => {
                     // if the file is modified/create more than 1 second ago, the event is most likely be fired by copy file to
                     // vault folder without using obsidian or sync file from remote (e.g. file manager of op system), we should ignore it.
                     const curentTime = new Date().getTime();
@@ -177,134 +180,135 @@ export default class AttachmentManagementPlugin extends Plugin {
                     }
 
                     this.createdQueue.push(file);
-                });
-            })
-        );
+                })
+            );
 
-        this.registerEvent(
-            this.app.vault.on("modify", (file: TAbstractFile) => {
-                debugLog("on modify event - create queue:", this.createdQueue);
-                if (this.createdQueue.length < 1 || !(file instanceof TFile)) {
-                    return;
-                }
+            this.registerEvent(
+                this.app.vault.on("modify", (file: TAbstractFile) => {
+                    debugLog("on modify event - create queue:", this.createdQueue);
+                    if (this.createdQueue.length < 1 || !(file instanceof TFile)) {
+                        return;
+                    }
 
-                debugLog("on modify event - file:", file.path);
-                this.app.vault.adapter.process(file.path, (data) => {
-                    // debugLog("on modify event - file content:", data);
-                    // processing one file at one event loop, other files will be processed in the next event loop
-                    const f = this.createdQueue.first();
-                    if (f != undefined) {
-                        this.app.vault.adapter.exists(f.path, true).then((exist) => {
-                            if (exist) {
-                                const processor = new CreateHandler(this, this.settings);
-                                const link = this.app.fileManager.generateMarkdownLink(f, file.path);
-                                if (
-                                    (file.extension == "md" && data.indexOf(link) != -1) ||
-                                    (file.extension == "canvas" && data.indexOf(f.path) != -1)
-                                ) {
+                    debugLog("on modify event - file:", file.path);
+                    this.app.vault.adapter.process(file.path, (data) => {
+                        // debugLog("on modify event - file content:", data);
+                        // processing one file at one event loop, other files will be processed in the next event loop
+                        const f = this.createdQueue.first();
+                        if (f != undefined) {
+                            this.app.vault.adapter.exists(f.path, true).then((exist) => {
+                                if (exist) {
+                                    const processor = new CreateHandler(this, this.settings);
+                                    const link = this.app.fileManager.generateMarkdownLink(f, file.path);
+                                    if (
+                                        (file.extension == "md" && data.indexOf(link) != -1) ||
+                                        (file.extension == "canvas" && data.indexOf(f.path) != -1)
+                                    ) {
+                                        this.createdQueue.remove(f);
+                                        processor.processAttach(f, file);
+                                    }
+                                } else {
+                                    // remove not exists file
+                                    debugLog("on modify event - file does not exist:", f.path);
                                     this.createdQueue.remove(f);
-                                    processor.processAttach(f, file);
                                 }
-                            } else {
-                                // remove not exists file
-                                debugLog("on modify event - file does not exist:", f.path);
-                                this.createdQueue.remove(f);
+                            });
+                        }
+                        return data;
+                    });
+                })
+            );
+
+            this.registerEvent(
+                // when trigger a rename event on folder, for each file/folder in this renamed folder (include itself) will trigger this event
+                this.app.vault.on("rename", async (file: TAbstractFile, oldPath: string) => {
+                    debugLog("on rename event - new path and old path:", file.path, oldPath);
+
+                    const { setting } = getRenameOverrideSetting(this.settings, file, oldPath);
+                    // update the override setting
+                    debugLog("rename - using settings:", setting);
+                    if (setting.type === SETTINGS_TYPES.FOLDER || setting.type === SETTINGS_TYPES.FILE) {
+                        updateOverrideSetting(this.settings, file, oldPath);
+                        await this.saveSettings();
+                        await this.loadSettings();
+                    }
+                    debugLog("rename - updated settings:", setting);
+
+                    if (!this.settings.autoRenameAttachment) {
+                        debugLog("rename - auto rename not enabled:", this.settings.autoRenameAttachment);
+                        return;
+                    }
+
+                    if (file instanceof TFile) {
+                        if (file.parent && isExcluded(file.parent.path, this.settings)) {
+                            debugLog("rename - exclude path:", file.parent.path);
+                            new Notice(`${file.path} was excluded, skipped`);
+                            return;
+                        }
+
+                        // ignore attachment
+                        if (isAttachment(this.settings, file)) {
+                            debugLog("rename - not processing rename on attachment:", file.path);
+                            return;
+                        }
+
+                        await new ArrangeHandler(this.settings, this.app, this).rearrangeAttachment("file", file, oldPath);
+                        await this.saveSettings();
+
+                        const oldMetadata = getMetadata(oldPath);
+                        // if the user have used the ${date} in `Attachment path` this could be not working, since the date will be change.
+                        const oldAttachPath = oldMetadata.getAttachmentPath(setting, this.settings.dateFormat);
+                        this.app.vault.adapter.exists(oldAttachPath).then((exists) => {
+                            if (exists) {
+                                checkEmptyFolder(this.app.vault.adapter, oldAttachPath).then((empty) => {
+                                    if (empty) {
+                                        this.app.vault.adapter.rmdir(oldAttachPath, true);
+                                    }
+                                });
+                            }
+                        });
+                    } else if (file instanceof TFolder) {
+                        // ignore rename event of folder
+                        return;
+                    }
+                })
+            );
+
+            this.registerEvent(
+                this.app.vault.on("delete", async (file: TAbstractFile) => {
+                    debugLog("on delete event - file path:", file.path);
+
+                    if ((file.parent && isExcluded(file.parent.path, this.settings)) || isAttachment(this.settings, file)) {
+                        debugLog("delete - exclude path or the file is an attachment:", file.path);
+                        return;
+                    }
+
+                    if (deleteOverrideSetting(this.settings, file)) {
+                        await this.saveSettings();
+                        new Notice("Removed override setting of " + file.path);
+                    }
+
+                    if (file instanceof TFile) {
+                        const oldMetadata = getMetadata(file.path);
+                        const { setting } = getOverrideSetting(this.settings, file);
+                        const oldAttachPath = oldMetadata.getAttachmentPath(setting, this.settings.dateFormat);
+                        this.app.vault.adapter.exists(oldAttachPath, true).then((exists) => {
+                            if (exists) {
+                                checkEmptyFolder(this.app.vault.adapter, oldAttachPath).then((empty) => {
+                                    if (empty) {
+                                        this.app.vault.adapter.rmdir(oldAttachPath, true);
+                                    }
+                                });
                             }
                         });
                     }
-                    return data;
-                });
-            })
-        );
+                })
+            );
 
-        this.registerEvent(
-            // when trigger a rename event on folder, for each file/folder in this renamed folder (include itself) will trigger this event
-            this.app.vault.on("rename", async (file: TAbstractFile, oldPath: string) => {
-                debugLog("on rename event - new path and old path:", file.path, oldPath);
-
-                const { setting } = getRenameOverrideSetting(this.settings, file, oldPath);
-                // update the override setting
-                debugLog("rename - using settings:", setting);
-                if (setting.type === SETTINGS_TYPES.FOLDER || setting.type === SETTINGS_TYPES.FILE) {
-                    updateOverrideSetting(this.settings, file, oldPath);
-                    await this.saveSettings();
-                    await this.loadSettings();
-                }
-                debugLog("rename - updated settings:", setting);
-
-                if (!this.settings.autoRenameAttachment) {
-                    debugLog("rename - auto rename not enabled:", this.settings.autoRenameAttachment);
-                    return;
-                }
-
-                if (file instanceof TFile) {
-                    if (file.parent && isExcluded(file.parent.path, this.settings)) {
-                        debugLog("rename - exclude path:", file.parent.path);
-                        new Notice(`${file.path} was excluded, skipped`);
-                        return;
-                    }
-
-                    // ignore attachment
-                    if (isAttachment(this.settings, file)) {
-                        debugLog("rename - not processing rename on attachment:", file.path);
-                        return;
-                    }
-
-                    await new ArrangeHandler(this.settings, this.app, this).rearrangeAttachment("file", file, oldPath);
-                    await this.saveSettings();
-
-                    const oldMetadata = getMetadata(oldPath);
-                    // if the user have used the ${date} in `Attachment path` this could be not working, since the date will be change.
-                    const oldAttachPath = oldMetadata.getAttachmentPath(setting, this.settings.dateFormat);
-                    this.app.vault.adapter.exists(oldAttachPath).then((exists) => {
-                        if (exists) {
-                            checkEmptyFolder(this.app.vault.adapter, oldAttachPath).then((empty) => {
-                                if (empty) {
-                                    this.app.vault.adapter.rmdir(oldAttachPath, true);
-                                }
-                            });
-                        }
-                    });
-                } else if (file instanceof TFolder) {
-                    // ignore rename event of folder
-                    return;
-                }
-            })
-        );
-
-        this.registerEvent(
-            this.app.vault.on("delete", async (file: TAbstractFile) => {
-                debugLog("on delete event - file path:", file.path);
-
-                if ((file.parent && isExcluded(file.parent.path, this.settings)) || isAttachment(this.settings, file)) {
-                    debugLog("delete - exclude path or the file is an attachment:", file.path);
-                    return;
-                }
-
-                if (deleteOverrideSetting(this.settings, file)) {
-                    await this.saveSettings();
-                    new Notice("Removed override setting of " + file.path);
-                }
-
-                if (file instanceof TFile) {
-                    const oldMetadata = getMetadata(file.path);
-                    const { setting } = getOverrideSetting(this.settings, file);
-                    const oldAttachPath = oldMetadata.getAttachmentPath(setting, this.settings.dateFormat);
-                    this.app.vault.adapter.exists(oldAttachPath, true).then((exists) => {
-                        if (exists) {
-                            checkEmptyFolder(this.app.vault.adapter, oldAttachPath).then((empty) => {
-                                if (empty) {
-                                    this.app.vault.adapter.rmdir(oldAttachPath, true);
-                                }
-                            });
-                        }
-                    });
-                }
-            })
-        );
-
-        // This adds a settings tab so the user can configure various aspects of the plugin
-        this.addSettingTab(new SettingTab(this.app, this));
+            // This adds a settings tab so the user can configure various aspects of the plugin
+            this.addSettingTab(new SettingTab(this.app, this));
+        });
+        
     }
 
     async overrideConfiguration(file: TAbstractFile, setting: AttachmentPathSettings) {


### PR DESCRIPTION
Moves `onLayoutReady()` to enclose other callbacks (top of onload), avoid loop that was introduced in 1.6