### PR TITLE
Fix: rm empty folder on rename event

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,5 +5,6 @@
 	"description": "Customize your attachment path of notes independently with variables and auto rename it on change.",
 	"author": "trganda",
 	"authorUrl": "https://github.com/trganda",
+	"fundingUrl": "https://paypal.me/trganda",
 	"isDesktopOnly": false
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -144,11 +144,11 @@ export default class AttachmentManagementPlugin extends Plugin {
               return;
             }
 
-            new ArrangeHandler(this.settings, this.app, this)
-              .rearrangeAttachment(RearrangeType.FILE, file, oldPath)
-              .finally(() => {
-                this.saveSettings();
-              });
+            await new ArrangeHandler(this.settings, this.app, this).rearrangeAttachment(
+              RearrangeType.FILE,
+              file,
+              oldPath
+            );
 
             const oldMetadata = getMetadata(oldPath);
             // if the user have used the ${date} in `Attachment path` this could be not working, since the date will be change.


### PR DESCRIPTION
Bug fix:

- Remove the attachment folder if it's empty, https://github.com/trganda/obsidian-attachment-management/issues/137