### PR TITLE
Fix null attachPathFolder

### DIFF
--- a/src/create.ts
+++ b/src/create.ts
@@ -55,11 +55,10 @@ export class CreateHandler {
         // make sure the attachment path was created
         this.app.vault.adapter
           .exists(attachPath, true)
-          .then((exists) => {
+          .then(async (exists) => {
             if (!exists) {
-              this.app.vault.adapter.mkdir(attachPath).finally(() => {
-                debugLog("processAttach - create path:", attachPath);
-              });
+				await this.app.vault.adapter.mkdir(attachPath);
+          		debugLog("processAttach - create path:", attachPath);
             }
           })
           .finally(() => {


### PR DESCRIPTION
Using finally() will not block the thread. This may result in the attachPathFolder not being created when the last finally block is executed (in fact, I encountered this situation). In this case, the attachPathFolder obtained by the function deduplicateNewName is null, and the file cannot be renamed or copied to the attachPathFolder. 

Use await to wait for the folder to be created.