### PR TITLE
fix: rearrange all  linked attachments early break

### DIFF
--- a/src/arrange.ts
+++ b/src/arrange.ts
@@ -57,7 +57,7 @@ export class ArrangeHandler {
       const { setting } = getOverrideSetting(this.settings, innerFile);
 
       if (attachments[obNote].size == 0) {
-        break;
+        continue;
       }
 
       // create attachment path if it's not exists


### PR DESCRIPTION
"Rearrange all linked attachments" did not work because of early break in `rearrangeAttachment` method