### PR TITLE
fix: app -> this.app

### DIFF
--- a/src/arrange.ts
+++ b/src/arrange.ts
@@ -256,7 +256,7 @@ export class ArrangeHandler {
           }
         }
         // Any Additional Link
-        const linkMatches: LinkMatch[] = await getAllLinkMatchesInFile(obsFile, app);
+        const linkMatches: LinkMatch[] = await getAllLinkMatchesInFile(obsFile, this.app);
         for (const linkMatch of linkMatches) {
           if (isAttachment(settings, linkMatch.linkText)) {
             this.addToSet(attachmentsSet, linkMatch.linkText);
@@ -284,7 +284,7 @@ export class ArrangeHandler {
                 this.addToSet(attachmentsSet, node.file);
               }
             } else if (node.type == "text") {
-              const linkMatches: LinkMatch[] = await getAllLinkMatchesInFile(obsFile, app, node.text);
+              const linkMatches: LinkMatch[] = await getAllLinkMatchesInFile(obsFile, this.app, node.text);
               for (const linkMatch of linkMatches) {
                 if (isAttachment(settings, linkMatch.linkText)) {
                   this.addToSet(attachmentsSet, linkMatch.linkText);


### PR DESCRIPTION
Description

Fixed TypeScript build errors caused by incorrect references to app instead of this.app in src/arrange.ts.
The build previously failed with the following errors:
I can only speak Japanese, so I translate it into English.

~~~
> pnpm run build

> obsidian-attachment-management@0.9.16 build D:\Data\obsidian-attachment-management
> tsc -noEmit -skipLibCheck && cross-env BUILD_ENV=production node esbuild.config.mjs

src/arrange.ts:259:81 - error TS2663: Cannot find name 'app'. Did you mean the instance member 'this.app'?

259         const linkMatches: LinkMatch[] = await getAllLinkMatchesInFile(obsFile, app);
                                                                                    ~~~

src/arrange.ts:287:87 - error TS2663: Cannot find name 'app'. Did you mean the instance member 'this.app'?

287               const linkMatches: LinkMatch[] = await getAllLinkMatchesInFile(obsFile, app, node.text);
                                                                                          ~~~


Found 2 errors in the same file, starting at: src/arrange.ts:259

 ELIFECYCLE  Command failed with exit code 2.
~~~

Changes

Replaced app with this.app in two locations within arrange.ts

Verified that the project now builds successfully with pnpm run build

Result

✅ TypeScript build passes without errors.