### PR TITLE
ci: switch release workflow to pnpm and add SLSA provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,13 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v3
+      - name: pnpm
+        uses: pnpm/action-setup@v4
       - name: Nodejs
         uses: actions/setup-node@v3
         with:
           node-version: latest
+          cache: pnpm
 
       - name: Build Changelog
         id: release_changelog
@@ -29,8 +32,8 @@ jobs:
       - name: Build
         id: build
         run: |
-          npm install
-          npm run build
+          pnpm install --frozen-lockfile
+          pnpm run build
           mkdir ${{ env.PLUGIN_NAME }}
           cp main.js manifest.json styles.css ${{ env.PLUGIN_NAME }}
           zip -r ${{ env.PLUGIN_NAME }}-${{ github.ref_name }}.zip ${{ env.PLUGIN_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,19 +13,21 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       - name: Nodejs
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: latest
           cache: pnpm
 
       - name: Build Changelog
         id: release_changelog
-        uses: mikepenz/release-changelog-builder-action@v3
+        uses: mikepenz/release-changelog-builder-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -38,6 +40,15 @@ jobs:
           cp main.js manifest.json styles.css ${{ env.PLUGIN_NAME }}
           zip -r ${{ env.PLUGIN_NAME }}-${{ github.ref_name }}.zip ${{ env.PLUGIN_NAME }}
           ls
+
+      - name: Generate SLSA build provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: |
+            main.js
+            manifest.json
+            styles.css
+            ${{ env.PLUGIN_NAME }}-${{ github.ref_name }}.zip
 
       - name: Release
         id: release


### PR DESCRIPTION
## Summary

- **Switch the release workflow from npm to pnpm** so CI matches the local toolchain (`packageManager` is pinned in `package.json` and `pnpm-lock.yaml` is committed). Adds `pnpm/action-setup`, enables setup-node's pnpm cache, and uses `pnpm install --frozen-lockfile` so CI cannot silently regenerate the lockfile.
- **Add SLSA v1.0 build provenance** via `actions/attest-build-provenance@v4`. The attestation is sigstore-signed using the runner's OIDC token and covers `main.js`, `manifest.json`, `styles.css`, and the release zip. Verifiable on the consumer side with `gh attestation verify <file> --owner trganda`. Required permissions (`id-token: write`, `attestations: write`) added.
- **Bump action versions** to current majors:
  - `actions/checkout` v3 → v6
  - `actions/setup-node` v3 → v6
  - `pnpm/action-setup` v4 → v6
  - `mikepenz/release-changelog-builder-action` v3 → v6
  - `ncipollo/release-action` stays on v1 (still its latest major)

## Test plan

- [ ] Push a throwaway tag (e.g. `v0.0.0-test`) on a non-main branch and verify the workflow:
  - [ ] Installs via pnpm (logs show `pnpm install --frozen-lockfile`, no lockfile regen warnings)
  - [ ] Builds `main.js` successfully
  - [ ] Produces an attestation (Actions run summary shows the "Generate SLSA build provenance" step succeeded and links to an attestation)
  - [ ] Uploads release assets via `ncipollo/release-action`
- [ ] After workflow runs, locally: `gh attestation verify main.js --owner trganda` succeeds.

## Notes

- `node-version: latest` was left untouched but is worth pinning to an LTS in a follow-up — `latest` will pull a brand-new Node release whenever one is published, which is a CI-stability risk.
- The workflow runs on every tag push. Since the 0.11.0 release was cut locally with `gh release create`, the next time a tag is pushed this workflow will create/update the release — verify the assets it produces don't conflict with anything already attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)