### PR TITLE
perf: debounce rename Notice to avoid UI flooding

### DIFF
--- a/src/create.ts
+++ b/src/create.ts
@@ -1,4 +1,4 @@
-import { App, Plugin, Notice, TFile, TFolder, normalizePath, MarkdownView } from "obsidian";
+import { App, Plugin, Notice, TFile, TFolder, debounce, normalizePath, MarkdownView } from "obsidian";
 import { deduplicateNewName } from "./lib/deduplicate";
 import { path } from "./lib/path";
 import { debugLog } from "./lib/log";
@@ -10,6 +10,33 @@ import { getExtensionOverrideSetting } from "./model/extensionOverride";
 import { isImage, isPastedImage } from "./utils";
 import { t } from "./i18n/index";
 // import { saveOriginalName } from "./lib/originalStorage";
+
+// Batch rename notices so rapid renames (e.g. paste bursts, rearrange-driven
+// rename cascades) collapse into a single Notice instead of flooding the UI.
+type RenameRecord = { from: string; to: string };
+const pendingRenameNotices: RenameRecord[] = [];
+
+const flushRenameNotices = debounce(
+  () => {
+    if (pendingRenameNotices.length === 0) {
+      return;
+    }
+    if (pendingRenameNotices.length === 1) {
+      const { from, to } = pendingRenameNotices[0];
+      new Notice(t("notices.fileRenamed", { from, to }));
+    } else {
+      new Notice(t("notices.filesRenamedBatch", { count: pendingRenameNotices.length }));
+    }
+    pendingRenameNotices.length = 0;
+  },
+  500,
+  true,
+);
+
+function queueRenameNotice(from: string, to: string) {
+  pendingRenameNotices.push({ from, to });
+  flushRenameNotices();
+}
 
 export class CreateHandler {
   readonly plugin: Plugin;
@@ -95,7 +122,7 @@ export class CreateHandler {
       .rename(attach, dst)
       .then(() => {
         if (name !== attachName) {
-          new Notice(t("notices.fileRenamed", { from: name, to: attachName }));
+          queueRenameNotice(name, attachName);
         }
 
         // Generate the new link after renaming (attach.path is now updated by vault.rename)

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -121,6 +121,7 @@ export const en = {
     fileExcluded: "{path} was excluded",
     overrideRemoved: "Removed override setting of {path}",
     fileRenamed: "Renamed {from} to {to}",
+    filesRenamedBatch: "Renamed {count} attachments",
     arrangeCompleted: "Arrange completed",
     resetAttachmentSetting: "Reset attachment setting of {path}",
     error: {

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -121,6 +121,7 @@ export const ja = {
     fileExcluded: "{path} は除外されました",
     overrideRemoved: "{path} の上書き設定を削除しました",
     fileRenamed: "{from} から {to} にリネームしました",
+    filesRenamedBatch: "{count} 件の添付ファイルをリネームしました",
     arrangeCompleted: "整理が完了しました",
     resetAttachmentSetting: "{path} の添付ファイル設定をリセットしました",
     error: {

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -121,6 +121,7 @@ export const zhCn = {
     fileExcluded: "{path} 已被排除",
     overrideRemoved: "已移除 {path} 的覆盖设置",
     fileRenamed: "已将 {from} 重命名为 {to}",
+    filesRenamedBatch: "已重命名 {count} 个附件",
     arrangeCompleted: "整理完成",
     resetAttachmentSetting: "已重置 {path} 的附件设置",
     error: {


### PR DESCRIPTION
## Summary

- Batches `renameCreateFile` Notices behind a 500ms debounce in [src/create.ts](src/create.ts) so a burst of attachment renames produces a single `Renamed N attachments` Notice instead of N individual ones.
- A single rename in the window keeps the existing detailed `Renamed X to Y` message — only bursts collapse.
- Adds `notices.filesRenamedBatch` translation key to `en`, `zh`, `ja` locales.

## Motivation

When many attachments are renamed in quick succession (paste/drop bursts, or any future code path routed through `CreateHandler.renameCreateFile`), the per-file Notice flood was visibly slowing the Obsidian UI.

## Test plan

- [ ] Paste a single image and confirm the `Renamed X to Y` Notice still appears with the original detail.
- [ ] Paste multiple images in rapid succession and confirm only one `Renamed N attachments` Notice appears.
- [ ] Verify `pnpm run build` succeeds (typecheck + bundle).
- [ ] Spot-check translations in `zh` and `ja` UI locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)