### PR TITLE
feat: restore mixed ${originalname} usage and storage persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Obsidian Attachment Management
 
-> **⚠ Breaking change in v0.11.0** — `${originalname}` persistence has been removed. `${originalname}` may now only be used as the **sole value** of *Attachment Format*; combining it with other text or variables is rejected with an inline error. If your previous format was something like `IMG-${originalname}` or `${originalname}-${date}`, update it before reloading the plugin. See the [Original Name](#original-name) section for migration details.
-
 This plugin supports more flexibly setting your attachment location with variables like `${notepath}`, `${notename}`, `${date}` and `${md5}`. An override setting feature can be used to change the global setting of a folder, file or extension.
 
 > Read the [Original Name](#original-name) section before using the `${originalname}` variable. Read the [FAQ](#faq) section if you have any questions about how to use this plugin.
@@ -37,13 +35,13 @@ If you want to reset the settings of files or folders to the global setting, use
 
 ### Original Name
 
-> **⚠ Breaking change (since v0.10.0):** the `${originalname}` persistence layer (`originalNameStorage` in `data.json`) and the `Clear unused original name storage` command have been **removed**. `${originalname}` can now only be used as the **sole value** of *Attachment Format* — combining it with other text or variables (e.g. `IMG-${originalname}` or `${originalname}-${date}`) is rejected by the settings validator with an inline error.
->
-> **Migration:** if your previous *Attachment Format* combined `${originalname}` with other parts, change it to either a plain `${originalname}` (to keep the original filename verbatim) or a format that does not reference `${originalname}`. The `originalNameStorage` entries in `data.json` are no longer read and can be deleted manually.
+The `${originalname}` variable represents the filename (without extension) of the attachment at the moment it was first added to the vault. You can use it on its own (e.g. `${originalname}`) or combine it with other text and variables (e.g. `IMG-${originalname}-${date}`).
 
-The `${originalname}` variable represents the original filename (without extension) of the attachment when it was first added to the vault. To keep that original filename, set the **Attachment Format** to exactly `${originalname}`.
+The plugin persists the original name in `data.json` under `originalNameStorage`, keyed by the file's MD5 hash. This means that even after the attachment has been renamed by the plugin or by a subsequent `Rearrange linked attachments` run, `${originalname}` will still resolve to the truly-original basename.
 
-Because the original name is no longer persisted, on every later create or rearrange event the plugin uses the attachment's current filename as `${originalname}`. Renaming an attachment and then running rearrange will not restore the original name.
+> **Note on duplicate content:** the storage is keyed by MD5, so two attachments with identical bytes share a single record. If you paste/drop two distinct files that happen to have the same content, only one original name will be retained for that md5; both files will resolve `${originalname}` to that same value.
+
+Use the command **Clear unused original name storage** to prune entries whose file is no longer linked in the vault.
 
 ## Roadmap of Features
 
@@ -77,7 +75,7 @@ And you can use the variables below to config:
 - `${originalname}`: The **filename** of the attachment file when it was first created in Obsidian.
 - `${date}`: Date time format by [Moment format options](https://momentjscom.readthedocs.io/en/latest/moment/04-displaying/01-format)
 
-> **Notice** before using `${originalname}`: the plugin does **not persist** the original filename. It is captured only at create time (first time the attachment is added to Obsidian). As of v0.10.0 `${originalname}` must be used as the sole value of *Attachment Format* — see the [Original Name](#original-name) section above.
+> **Notice** before using `${originalname}`: see the [Original Name](#original-name) section for how the original filename is persisted and how duplicate-content files are handled.
 
 ### Root Path to Save New Attachments
 

--- a/src/arrange.ts
+++ b/src/arrange.ts
@@ -19,11 +19,11 @@ export enum RearrangeType {
 }
 
 export class ArrangeHandler {
-  settings: AttachmentManagementPluginSettings;
+  pluginSettings: AttachmentManagementPluginSettings;
   app: App;
 
   constructor(settings: AttachmentManagementPluginSettings, app: App) {
-    this.settings = settings;
+    this.pluginSettings = settings;
     this.app = app;
   }
 
@@ -36,21 +36,21 @@ export class ArrangeHandler {
    * @param {string} oldPath - The old path of the file (optional), used for rename event.
    */
   async rearrangeAttachment(type: RearrangeType, file?: TFile, oldPath?: string) {
-    if (!this.settings.autoRenameAttachment) {
+    if (!this.pluginSettings.autoRenameAttachment) {
       debugLog("rearrangeAttachment - autoRenameAttachment not enable");
       return;
     }
 
     // only rearrange attachment that linked by markdown or canvas
-    const attachments = await this.getAttachmentsInVault(this.settings, type, file, oldPath);
+    const attachments = await this.getAttachmentsInVault(this.pluginSettings, type, file, oldPath);
     debugLog("rearrangeAttachment - attachments:", Object.keys(attachments).length, Object.entries(attachments));
     for (const obNote of Object.keys(attachments)) {
       const innerFile = this.app.vault.getAbstractFileByPath(obNote);
-      if (!(innerFile instanceof TFile) || isAttachment(this.app, this.settings, innerFile)) {
+      if (!(innerFile instanceof TFile) || isAttachment(this.app, this.pluginSettings, innerFile)) {
         debugLog(`rearrangeAttachment - ${obNote} not exists or is attachment, skipped`);
         continue;
       }
-      const { setting } = getOverrideSetting(this.settings, innerFile);
+      const { setting } = getOverrideSetting(this.pluginSettings, innerFile);
 
       if (attachments[obNote].size == 0) {
         continue;
@@ -88,9 +88,10 @@ export class ArrangeHandler {
         const metadata = getMetadata(obNote, linkFile);
         const attachName = await metadata.getAttachFileName(
           setting,
-          this.settings.dateFormat,
+          this.pluginSettings.dateFormat,
           linkFile,
           this.app.vault.adapter,
+          this.pluginSettings,
         );
 
         // ignore if the path was equal to current link
@@ -159,8 +160,8 @@ export class ArrangeHandler {
       const file = getActiveFile(this.app);
       if (file) {
         if (
-          (file.parent && isExcluded(file.parent.path, this.settings)) ||
-          isAttachment(this.app, this.settings, file)
+          (file.parent && isExcluded(file.parent.path, this.pluginSettings)) ||
+          isAttachment(this.app, this.pluginSettings, file)
         ) {
           allFiles = [];
           // new Notice(`${file.path} was excluded, skipped`);
@@ -174,7 +175,10 @@ export class ArrangeHandler {
         }
       }
     } else if (type == RearrangeType.FILE && file != undefined) {
-      if ((file.parent && isExcluded(file.parent.path, this.settings)) || isAttachment(this.app, this.settings, file)) {
+      if (
+        (file.parent && isExcluded(file.parent.path, this.pluginSettings)) ||
+        isAttachment(this.app, this.pluginSettings, file)
+      ) {
         allFiles = [];
         // new Notice(`${file.path} was excluded, skipped`);
       } else {

--- a/src/create.ts
+++ b/src/create.ts
@@ -1,4 +1,4 @@
-import { App, Plugin, Notice, TFile, TFolder, normalizePath, MarkdownView } from "obsidian";
+import { App, Plugin, Notice, TFile, TFolder, debounce, normalizePath, MarkdownView } from "obsidian";
 import { deduplicateNewName } from "./lib/deduplicate";
 import { path } from "./lib/path";
 import { debugLog } from "./lib/log";
@@ -10,6 +10,33 @@ import { getExtensionOverrideSetting } from "./model/extensionOverride";
 import { isImage, isPastedImage } from "./utils";
 import { t } from "./i18n/index";
 // import { saveOriginalName } from "./lib/originalStorage";
+
+// Batch rename notices so rapid renames (e.g. paste bursts, rearrange-driven
+// rename cascades) collapse into a single Notice instead of flooding the UI.
+type RenameRecord = { from: string; to: string };
+const pendingRenameNotices: RenameRecord[] = [];
+
+const flushRenameNotices = debounce(
+  () => {
+    if (pendingRenameNotices.length === 0) {
+      return;
+    }
+    if (pendingRenameNotices.length === 1) {
+      const { from, to } = pendingRenameNotices[0];
+      new Notice(t("notices.fileRenamed", { from, to }));
+    } else {
+      new Notice(t("notices.filesRenamedBatch", { count: pendingRenameNotices.length }));
+    }
+    pendingRenameNotices.length = 0;
+  },
+  500,
+  true,
+);
+
+function queueRenameNotice(from: string, to: string) {
+  pendingRenameNotices.push({ from, to });
+  flushRenameNotices();
+}
 
 export class CreateHandler {
   readonly plugin: Plugin;
@@ -95,7 +122,7 @@ export class CreateHandler {
       .rename(attach, dst)
       .then(() => {
         if (name !== attachName) {
-          new Notice(t("notices.fileRenamed", { from: name, to: attachName }));
+          queueRenameNotice(name, attachName);
         }
 
         // Generate the new link after renaming (attach.path is now updated by vault.rename)

--- a/src/create.ts
+++ b/src/create.ts
@@ -7,9 +7,9 @@ import { getOverrideSetting } from "./override";
 import { getMetadata } from "./settings/metadata";
 import { isExcluded } from "./exclude";
 import { getExtensionOverrideSetting } from "./model/extensionOverride";
-import { isImage, isPastedImage } from "./utils";
+import { isImage, isPastedImage, md5sum } from "./utils";
+import { saveOriginalName } from "./lib/originalStorage";
 import { t } from "./i18n/index";
-// import { saveOriginalName } from "./lib/originalStorage";
 
 // Batch rename notices so rapid renames (e.g. paste bursts, rearrange-driven
 // rename cascades) collapse into a single Notice instead of flooding the UI.
@@ -112,6 +112,9 @@ export class CreateHandler {
     debugLog("renameFile - ", attach.path, " to ", dst);
 
     const name = attach.name;
+    // Capture the pre-rename basename so ${originalname} resolves to it on
+    // future runs (rearrange, etc.), even after this file has been renamed.
+    const originalBasename = attach.basename;
 
     // Generate the old link before renaming, to find and replace it later
     const oldLink = this.app.fileManager.generateMarkdownLink(attach, source.path);
@@ -133,16 +136,14 @@ export class CreateHandler {
         this.updateLinkInSource(source, oldLink, newLink);
       })
       .finally(() => {
-        // save origianl name in setting
-        // const { setting } = getOverrideSetting(this.settings, source);
-        // md5sum(this.app.vault.adapter, attach).then((md5) => {
-        //   saveOriginalName(this.settings, setting, attach.extension, {
-        //     n: original,
-        //     md5: md5,
-        //   });
-
-        // });
-        this.plugin.saveData(this.settings);
+        const { setting } = getOverrideSetting(this.settings, source);
+        md5sum(this.app.vault.adapter, attach).then((md5) => {
+          saveOriginalName(this.settings, setting, attach.extension, {
+            n: originalBasename,
+            md5: md5,
+          });
+          this.plugin.saveData(this.settings);
+        });
       });
   }
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -133,6 +133,7 @@ export const en = {
     rearrangeAllLinks: "Rearrange all linked attachments",
     rearrangeActiveLinks: "Rearrange linked attachments",
     resetOverrideSetting: "Reset override setting",
+    clearUnusedStorage: "Clear unused original name storage",
   },
 
   errors: {
@@ -142,8 +143,6 @@ export const en = {
     duplicateExtension: "Duplicate extension override.",
     excludedExtension: "Extension override cannot be an excluded extension.",
     attachFormatEmpty: "Attachment format cannot be empty.",
-    attachFormatOriginalnameMixed:
-      "${originalname} must be used alone; it cannot be combined with other text or variables.",
     attachFormatIllegalChar: "Attachment format contains illegal filename character: {char}",
     attachFormatUnknownVariable: "Unknown variable in attachment format: {name}",
     attachmentPathEmpty: "Attachment path cannot be empty.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -121,6 +121,7 @@ export const en = {
     fileExcluded: "{path} was excluded",
     overrideRemoved: "Removed override setting of {path}",
     fileRenamed: "Renamed {from} to {to}",
+    filesRenamedBatch: "Renamed {count} attachments",
     arrangeCompleted: "Arrange completed",
     resetAttachmentSetting: "Reset attachment setting of {path}",
     error: {

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -121,6 +121,7 @@ export const ja = {
     fileExcluded: "{path} は除外されました",
     overrideRemoved: "{path} の上書き設定を削除しました",
     fileRenamed: "{from} から {to} にリネームしました",
+    filesRenamedBatch: "{count} 件の添付ファイルをリネームしました",
     arrangeCompleted: "整理が完了しました",
     resetAttachmentSetting: "{path} の添付ファイル設定をリセットしました",
     error: {

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -133,6 +133,7 @@ export const ja = {
     rearrangeAllLinks: "リンクされているすべての添付ファイルを再整理",
     rearrangeActiveLinks: "リンクされている添付ファイルを再整理",
     resetOverrideSetting: "上書き設定をリセット",
+    clearUnusedStorage: "未使用の元のファイル名ストレージをクリア",
   },
 
   errors: {
@@ -142,8 +143,6 @@ export const ja = {
     duplicateExtension: "重複した拡張子ごとの上書き設定。",
     excludedExtension: "拡張子ごとの上書き設定は、除外された拡張子にできません。",
     attachFormatEmpty: "添付ファイルのフォーマットを空にできません。",
-    attachFormatOriginalnameMixed:
-      "${originalname} は単独で使用する必要があります。他のテキストや変数と組み合わせることはできません。",
     attachFormatIllegalChar: "添付ファイルのフォーマットに不正なファイル名文字が含まれています：{char}",
     attachFormatUnknownVariable: "添付ファイルのフォーマット内の未知の変数：{name}",
     attachmentPathEmpty: "添付ファイルのパスを空にできません。",

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -133,6 +133,7 @@ export const zhCn = {
     rearrangeAllLinks: "重新整理所有链接的附件",
     rearrangeActiveLinks: "重新整理链接的附件",
     resetOverrideSetting: "重置覆盖设置",
+    clearUnusedStorage: "清理未使用的原始文件名存储",
   },
 
   errors: {
@@ -142,7 +143,6 @@ export const zhCn = {
     duplicateExtension: "重复的扩展覆盖。",
     excludedExtension: "扩展覆盖不能是被排除的扩展。",
     attachFormatEmpty: "附件格式不能为空。",
-    attachFormatOriginalnameMixed: "${originalname} 必须单独使用，不能与其他文本或变量组合。",
     attachFormatIllegalChar: "附件格式包含非法文件名字符：{char}",
     attachFormatUnknownVariable: "附件格式中存在未知变量：{name}",
     attachmentPathEmpty: "附件路径不能为空。",

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -121,6 +121,7 @@ export const zhCn = {
     fileExcluded: "{path} 已被排除",
     overrideRemoved: "已移除 {path} 的覆盖设置",
     fileRenamed: "已将 {from} 重命名为 {to}",
+    filesRenamedBatch: "已重命名 {count} 个附件",
     arrangeCompleted: "整理完成",
     resetAttachmentSetting: "已重置 {path} 的附件设置",
     error: {

--- a/src/lib/originalStorage.ts
+++ b/src/lib/originalStorage.ts
@@ -1,63 +1,45 @@
 import { getExtensionOverrideSetting } from "../model/extensionOverride";
-import { AttachmentPathSettings } from "../settings/settings";
+import { AttachmentManagementPluginSettings, AttachmentPathSettings, OriginalNameStorage } from "../settings/settings";
 import { SETTINGS_VARIABLES_ORIGINALNAME } from "./constant";
 
-export function isOriginalNameVariable(setting: AttachmentPathSettings, ext: string): boolean {
+export function containsOriginalNameVariable(setting: AttachmentPathSettings, ext: string): boolean {
   const { extSetting } = getExtensionOverrideSetting(ext, setting);
-  if (
-    (extSetting !== undefined && extSetting.attachFormat.trim() === SETTINGS_VARIABLES_ORIGINALNAME) ||
-    setting.attachFormat.trim() === SETTINGS_VARIABLES_ORIGINALNAME
-  ) {
-    return true;
+  if (extSetting !== undefined) {
+    return extSetting.attachFormat.includes(SETTINGS_VARIABLES_ORIGINALNAME);
   }
-  return false;
+  return setting.attachFormat.includes(SETTINGS_VARIABLES_ORIGINALNAME);
 }
 
-// export function saveOriginalName(
-//   settings: AttachmentManagementPluginSettings,
-//   setting: AttachmentPathSettings,
-//   ext: string,
-//   data: OriginalNameStorage
-// ) {
-//   if (settings.originalNameStorage === undefined) {
-//     settings.originalNameStorage = [];
-//   }
+export function saveOriginalName(
+  settings: AttachmentManagementPluginSettings,
+  setting: AttachmentPathSettings,
+  ext: string,
+  data: OriginalNameStorage,
+) {
+  if (settings.originalNameStorage === undefined) {
+    settings.originalNameStorage = [];
+  }
+  if (!containsOriginalNameVariable(setting, ext)) {
+    return;
+  }
+  settings.originalNameStorage.filter((n) => n.md5 === data.md5).forEach((n) => settings.originalNameStorage.remove(n));
+  settings.originalNameStorage.push(data);
+}
 
-//   if (containOriginalNameVariable(setting, ext)) {
-//     settings.originalNameStorage
-//       .filter((n) => n.md5 == data.md5)
-//       .forEach((n) => settings.originalNameStorage.remove(n));
-//     settings.originalNameStorage.push(data);
-//   }
-// }
+export function loadOriginalName(
+  settings: AttachmentManagementPluginSettings,
+  setting: AttachmentPathSettings,
+  ext: string,
+  md5: string,
+): OriginalNameStorage | undefined {
+  if (!containsOriginalNameVariable(setting, ext)) {
+    return undefined;
+  }
+  return settings.originalNameStorage.find((data) => data.md5 === md5);
+}
 
-// export function loadOriginalName(
-//   settings: AttachmentManagementPluginSettings,
-//   setting: AttachmentPathSettings,
-//   ext: string,
-//   md5: string
-// ): OriginalNameStorage | undefined {
-//   if (containOriginalNameVariable(setting, ext)) {
-//     const first = settings.originalNameStorage.find((data) => data.md5 === md5);
-//     const last = settings.originalNameStorage.reverse().find((data) => data.md5 === md5);
-
-//     if (first === undefined || last == undefined) {
-//       return undefined;
-//     }
-//     if (first.md5 === last.md5 && first.n === last.n) {
-//       return last;
-//     } else if (first.md5 === last.md5 && first.n !== last.n) {
-//       // remove duplicated item, choice the oldder one
-//       settings.originalNameStorage.remove(first);
-//       return last;
-//     }
-//   }
-//   return undefined;
-// }
-
-// export function rmOriginalName(settings: AttachmentManagementPluginSettings, md5: string) {
-//   const prepares = settings.originalNameStorage.filter((data) => (data.md5 = md5));
-//   prepares.forEach((p) => {
-//     settings.originalNameStorage.remove(p);
-//   });
-// }
+export function rmOriginalName(settings: AttachmentManagementPluginSettings, md5: string) {
+  settings.originalNameStorage
+    .filter((data) => data.md5 === md5)
+    .forEach((p) => settings.originalNameStorage.remove(p));
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ import { initI18n, t } from "./i18n/index";
 import { ConfirmModal } from "./model/confirm";
 import { checkEmptyFolder, getActiveFile } from "./commons";
 import { deleteOverrideSetting, getOverrideSetting, getRenameOverrideSetting, updateOverrideSetting } from "./override";
-import { isAttachment, isMarkdownFile, isCanvasFile, matchExtension } from "./utils";
+import { isAttachment, isMarkdownFile, isCanvasFile, matchExtension, md5sum } from "./utils";
 import { ArrangeHandler, RearrangeType } from "./arrange";
 import { CreateHandler } from "./create";
 import { isExcluded } from "./exclude";
@@ -301,35 +301,29 @@ export default class AttachmentManagementPlugin extends Plugin {
       },
     });
 
-    // this.addCommand({
-    //   id: "attachment-management-clear-unused-originalname-storage",
-    //   name: t("commands.clearUnusedStorage"),
-    //   callback: async () => {
-    //     const attachments = await new ArrangeHandler(this.settings, this.app, this).getAttachmentsInVault(
-    //       this.settings,
-    //       RearrangeType.LINKS
-    //     );
-    //     const storages: OriginalNameStorage[] = [];
-    //     for (const attachs of Object.values(attachments)) {
-    //       for (const attach of attachs) {
-    //         const link = decodeURI(attach);
-    //         const linkFile = this.app.vault.getAbstractFileByPath(link);
-    //         if (linkFile !== null && linkFile instanceof TFile) {
-    //           md5sum(this.app.vault.adapter, linkFile).then((md5) => {
-    //             const ret = this.settings.originalNameStorage.find((data) => data.md5 === md5);
-    //             if (ret) {
-    //               storages.filter((n) => n.md5 == md5).forEach((n) => storages.remove(n));
-    //               storages.push(ret);
-    //             }
-    //           });
-    //         }
-    //       }
-    //     }
-    //     debugLog("clearUnusedOriginalNameStorage - storage:", storages);
-    //     this.settings.originalNameStorage = storages;
-    //     this.saveSettings();
-    //   },
-    // });
+    this.addCommand({
+      id: "attachment-management-clear-unused-originalname-storage",
+      name: t("commands.clearUnusedStorage"),
+      callback: async () => {
+        const attachments = await new ArrangeHandler(this.settings, this.app).getAttachmentsInVault(
+          this.settings,
+          RearrangeType.LINKS,
+        );
+        const validMd5s = new Set<string>();
+        for (const attachs of Object.values(attachments)) {
+          for (const attach of attachs) {
+            const link = decodeURI(attach);
+            const linkFile = this.app.vault.getAbstractFileByPath(link);
+            if (linkFile instanceof TFile) {
+              validMd5s.add(await md5sum(this.app.vault.adapter, linkFile));
+            }
+          }
+        }
+        this.settings.originalNameStorage = this.settings.originalNameStorage.filter((s) => validMd5s.has(s.md5));
+        debugLog("clearUnusedOriginalNameStorage - storage:", this.settings.originalNameStorage);
+        await this.saveSettings();
+      },
+    });
   }
 
   async loadSettings() {

--- a/src/settings/metadata.ts
+++ b/src/settings/metadata.ts
@@ -1,5 +1,5 @@
 import { DataAdapter, TFile, normalizePath } from "obsidian";
-import { AttachmentPathSettings, DEFAULT_SETTINGS } from "./settings";
+import { AttachmentManagementPluginSettings, AttachmentPathSettings, DEFAULT_SETTINGS } from "./settings";
 import {
   SETTINGS_VARIABLES_DATES,
   SETTINGS_VARIABLES_MD5,
@@ -12,6 +12,7 @@ import { getRootPath } from "../commons";
 import { path } from "../lib/path";
 import { md5sum } from "../utils";
 import { getExtensionOverrideSetting } from "../model/extensionOverride";
+import { loadOriginalName } from "../lib/originalStorage";
 import { debugLog } from "../lib/log";
 
 /**
@@ -62,6 +63,10 @@ class Metadata {
    * @param {AttachmentPathSettings} setting - attachment path settings object
    * @param {string} dateFormat - format string for date and time
    * @param {TFile} originalAttach - the original attachment file
+   * @param {DataAdapter} adapter - vault adapter (used for md5 hashing)
+   * @param {AttachmentManagementPluginSettings} [pluginSettings] - plugin settings; when provided
+   *   enables ${originalname} lookup from the persisted storage so the original
+   *   name survives subsequent renames (e.g. rearrange).
    * @return {string} the formatted attachment file name
    */
   async getAttachFileName(
@@ -69,6 +74,7 @@ class Metadata {
     dateFormat: string,
     originalAttach: TFile,
     adapter: DataAdapter,
+    pluginSettings?: AttachmentManagementPluginSettings,
   ): Promise<string> {
     // Anchor ${date} to the attachment's ctime
     const dateTime = window.moment(originalAttach.stat.ctime).format(dateFormat);
@@ -85,14 +91,21 @@ class Metadata {
       }
     }
 
-    if (attachFormat.trim() === SETTINGS_VARIABLES_ORIGINALNAME) {
-      return originalAttach.basename;
+    // Prefer the stored original name (keyed by md5) so the truly-original
+    // basename survives later renames. Fall back to the file's current basename.
+    let originalName = originalAttach.basename;
+    if (pluginSettings !== undefined && this.attachmentFile !== undefined) {
+      const stored = loadOriginalName(pluginSettings, setting, this.attachmentFile.extension, md5);
+      if (stored !== undefined) {
+        originalName = stored.n;
+      }
     }
 
     return attachFormat
       .replace(`${SETTINGS_VARIABLES_DATES}`, dateTime)
       .replace(`${SETTINGS_VARIABLES_NOTENAME}`, this.basename)
-      .replace(`${SETTINGS_VARIABLES_MD5}`, md5);
+      .replace(`${SETTINGS_VARIABLES_MD5}`, md5)
+      .replace(`${SETTINGS_VARIABLES_ORIGINALNAME}`, originalName);
   }
 
   /**

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -79,7 +79,7 @@ export interface AttachmentManagementPluginSettings {
   // Exclude subpath also
   excludeSubpaths: boolean;
   // Presistence storage of original name
-  // originalNameStorage: OriginalNameStorage[];
+  originalNameStorage: OriginalNameStorage[];
   // Path of notes that override global configuration
   overridePath: Record<string, AttachmentPathSettings>;
 }
@@ -98,7 +98,7 @@ export const DEFAULT_SETTINGS: AttachmentManagementPluginSettings = {
   excludedPaths: "",
   excludePathsArray: [],
   excludeSubpaths: false,
-  // originalNameStorage: [],
+  originalNameStorage: [],
   overridePath: {},
   disableNotification: false,
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -218,17 +218,12 @@ const VAR_TOKEN_RE = /\$\{[^}]+\}/g;
 
 export type AttachFormatError =
   | { type: "empty" }
-  | { type: "originalnameMixed" }
   | { type: "illegalChar"; char: string }
   | { type: "unknownVariable"; name: string };
 
 export function validateAttachFormat(value: string): AttachFormatError | null {
   const trimmed = value.trim();
   if (trimmed.length === 0) return { type: "empty" };
-
-  if (trimmed.includes(SETTINGS_VARIABLES_ORIGINALNAME) && trimmed !== SETTINGS_VARIABLES_ORIGINALNAME) {
-    return { type: "originalnameMixed" };
-  }
 
   const stripped = trimmed.replace(VAR_TOKEN_RE, "");
   const bad = stripped.match(ILLEGAL_FILENAME_CHARS);
@@ -247,8 +242,6 @@ export function attachFormatErrorMessage(err: AttachFormatError): string {
   switch (err.type) {
     case "empty":
       return t("errors.attachFormatEmpty");
-    case "originalnameMixed":
-      return t("errors.attachFormatOriginalnameMixed");
     case "illegalChar":
       return t("errors.attachFormatIllegalChar", { char: err.char });
     case "unknownVariable":


### PR DESCRIPTION
## Summary

- Re-enables `\${originalname}` as a regular variable that can be combined with other tokens (e.g. `IMG-\${originalname}-\${date}`). The previous \"must be used alone\" validation has been removed.
- Restores the `originalNameStorage` persistence layer so the original basename survives later renames and rearranges (lookup is keyed by MD5 of the file content).
- Restores the **Clear unused original name storage** command for pruning entries whose file is no longer linked.
- Updates [README](README.md): removes the v0.10.0/v0.11.0 breaking-change banners, documents the new behavior, and notes the MD5-collision caveat (two distinct files with identical content share a single storage record).

## Implementation notes

- [src/lib/originalStorage.ts](src/lib/originalStorage.ts) — restored `saveOriginalName` / `loadOriginalName` / `rmOriginalName`; renamed the predicate to `containsOriginalNameVariable` to reflect the new inclusion semantics.
- [src/settings/metadata.ts](src/settings/metadata.ts) — `getAttachFileName` now takes an optional `pluginSettings` to look up the original basename from storage, and substitutes `\${originalname}` via `.replace()` like the other variables.
- [src/create.ts](src/create.ts) — captures the pre-rename basename and persists it (keyed by md5) after each rename.
- [src/arrange.ts](src/arrange.ts) — threads `this.settings` into `getAttachFileName` so rearrange resolves `\${originalname}` from storage.
- [src/utils.ts](src/utils.ts) — drops the `originalnameMixed` validation type/case.
- [src/main.ts](src/main.ts) — re-registers the `Clear unused original name storage` command (set-based and properly awaited this time).
- i18n: adds `commands.clearUnusedStorage` to `en`/`zh`/`ja`, removes the now-orphan `errors.attachFormatOriginalnameMixed`.

## Test plan

- [x] Set Attachment Format to `IMG-\${originalname}-\${date}`, paste an image, confirm the rendered filename contains the original basename and renders without an inline validation error.
- [x] After the paste-rename, run `Rearrange linked attachments` on the note and confirm `\${originalname}` still resolves to the truly-original basename (not the post-rename name).
- [x] Inspect `data.json` and confirm `originalNameStorage` contains a record keyed by the file's md5.
- [x] Run **Clear unused original name storage** after deleting an attachment; confirm the stale entry is removed.
- [x] Verify settings tab in `zh` and `ja` locales loads without console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)